### PR TITLE
Add Comfact facade integration client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,31 @@
 							</configOptions>
 						</configuration>
 					</execution>
+					<execution>
+						<id>comfactfacade</id>
+						<goals>
+							<goal>generate</goal>
+						</goals>
+						<configuration>
+							<inputSpec>${project.basedir}/src/main/resources/contract/comfactfacade.yml</inputSpec>
+							<output>${generated-sources-path}</output>
+							<generatorName>spring</generatorName>
+							<generateApis>false</generateApis>
+							<generateSupportingFiles>false</generateSupportingFiles>
+							<configOptions>
+								<useSpringBoot4>true</useSpringBoot4>
+								<useJackson3>true</useJackson3>
+								<sourceFolder>${generated-sources-java-path}</sourceFolder>
+								<dateLibrary>java8</dateLibrary>
+								<modelPackage>generated.se.sundsvall.comfactfacade</modelPackage>
+								<openApiNullable>false</openApiNullable>
+								<generatePom>false</generatePom>
+								<useBeanValidation>false</useBeanValidation>
+								<useSwaggerAnnotations>false</useSwaggerAnnotations>
+								<interfaceOnly>true</interfaceOnly>
+							</configOptions>
+						</configuration>
+					</execution>
 				</executions>
 			</plugin>
 			<plugin>

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
@@ -1,0 +1,26 @@
+package se.sundsvall.esigning.integration.comfactfacade;
+
+import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningRequest;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.retry.annotation.Retry;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import se.sundsvall.esigning.integration.comfactfacade.configuration.ComfactFacadeConfiguration;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static se.sundsvall.esigning.integration.comfactfacade.configuration.ComfactFacadeConfiguration.CLIENT_ID;
+
+@FeignClient(
+	name = CLIENT_ID,
+	url = "${integration.comfactfacade.base-url}",
+	configuration = ComfactFacadeConfiguration.class)
+@CircuitBreaker(name = CLIENT_ID)
+public interface ComfactFacadeClient {
+
+	@Retry(name = CLIENT_ID)
+	@PostMapping(path = "/{municipalityId}/signings", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+	CreateSigningResponse createSigningRequest(@PathVariable("municipalityId") String municipalityId, @RequestBody SigningRequest request);
+}

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
@@ -1,0 +1,31 @@
+package se.sundsvall.esigning.integration.comfactfacade;
+
+import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import se.sundsvall.dept44.problem.ThrowableProblem;
+
+@Component
+public class ComfactFacadeIntegration {
+
+	private static final String COULD_NOT_CREATE_SIGNING = "Could not create signing instance at Comfact facade. Error: %s";
+	private static final Logger LOGGER = LoggerFactory.getLogger(ComfactFacadeIntegration.class);
+
+	private final ComfactFacadeClient comfactFacadeClient;
+
+	public ComfactFacadeIntegration(final ComfactFacadeClient comfactFacadeClient) {
+		this.comfactFacadeClient = comfactFacadeClient;
+	}
+
+	public CreateSigningResponse createSigning(final String municipalityId, final SigningRequest request) {
+		try {
+			return comfactFacadeClient.createSigningRequest(municipalityId, request);
+		} catch (final ThrowableProblem e) {
+			// Preserve the provider's original problem (status + detail) so the caller gets a clear error.
+			LOGGER.error(COULD_NOT_CREATE_SIGNING.formatted(e.getMessage()));
+			throw e;
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeConfiguration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeConfiguration.java
@@ -1,0 +1,24 @@
+package se.sundsvall.esigning.integration.comfactfacade.configuration;
+
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import se.sundsvall.dept44.configuration.feign.FeignConfiguration;
+import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
+import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
+
+@Import(FeignConfiguration.class)
+public class ComfactFacadeConfiguration {
+
+	public static final String CLIENT_ID = "comfactfacade";
+
+	@Bean
+	FeignBuilderCustomizer feignBuilderCustomizer(final ClientRegistrationRepository clientRepository, final ComfactFacadeProperties comfactFacadeProperties) {
+		return FeignMultiCustomizer.create()
+			.withErrorDecoder(new ProblemErrorDecoder(CLIENT_ID))
+			.withRequestTimeoutsInSeconds(comfactFacadeProperties.connectTimeout(), comfactFacadeProperties.readTimeout())
+			.withRetryableOAuth2InterceptorForClientRegistration(clientRepository.findByRegistrationId(CLIENT_ID))
+			.composeCustomizersToOne();
+	}
+}

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeProperties.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeProperties.java
@@ -1,0 +1,7 @@
+package se.sundsvall.esigning.integration.comfactfacade.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("integration.comfactfacade")
+public record ComfactFacadeProperties(int connectTimeout, int readTimeout) {
+}

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -25,3 +25,10 @@ config:
     client-secret: someClientSecret
     connect-timeout: 5
     read-timeout: 30
+  comfactfacade:
+    base-url: http://localhost:${wiremock.server.port}/comfactfacade
+    token-url: http://localhost:${wiremock.server.port}/token
+    client-id: someClientId
+    client-secret: someClientSecret
+    connect-timeout: 5
+    read-timeout: 30

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -26,3 +26,10 @@ config:
     client-secret: someClientSecret
     connect-timeout: 5
     read-timeout: 30
+  comfactfacade:
+    base-url: http://localhost:59999/comfactfacade
+    token-url: http://localhost:59999/token
+    client-id: someClientId
+    client-secret: someClientSecret
+    connect-timeout: 5
+    read-timeout: 30

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
             token-uri: ${config.esigningprocess.token-url}
           document:
             token-uri: ${config.document.token-url}
+          comfactfacade:
+            token-uri: ${config.comfactfacade.token-url}
         registration:
           esigningprocess:
             authorization-grant-type: client_credentials
@@ -30,6 +32,11 @@ spring:
             provider: document
             client-id: ${config.document.client-id}
             client-secret: ${config.document.client-secret}
+          comfactfacade:
+            authorization-grant-type: client_credentials
+            provider: comfactfacade
+            client-id: ${config.comfactfacade.client-id}
+            client-secret: ${config.comfactfacade.client-secret}
 integration:
   esigningprocess:
     connect-timeout: ${config.esigningprocess.connect-timeout}
@@ -39,3 +46,7 @@ integration:
     connect-timeout: ${config.document.connect-timeout}
     read-timeout: ${config.document.read-timeout}
     base-url: ${config.document.base-url}
+  comfactfacade:
+    connect-timeout: ${config.comfactfacade.connect-timeout}
+    read-timeout: ${config.comfactfacade.read-timeout}
+    base-url: ${config.comfactfacade.base-url}

--- a/src/main/resources/contract/comfactfacade.yml
+++ b/src/main/resources/contract/comfactfacade.yml
@@ -1,0 +1,806 @@
+openapi: 3.1.0
+info:
+  title: api-comfact-facade
+  contact: { }
+  license:
+    name: MIT License
+    url: https://opensource.org/licenses/MIT
+  version: "3.0"
+servers:
+  - url: http://localhost:59777
+    description: Generated server url
+tags:
+  - name: Signings
+    description: Signing operations
+paths:
+  /{municipalityId}/signings:
+    get:
+      tags:
+        - Signings
+      summary: Get all signing instances.
+      description: "The 'sort' parameter in the Pageable object can take the values\
+        \ 'SigningInstanceId', 'ReferenceNumber', 'CustomerReferenceNumber', 'Created',\
+        \ 'Changed', 'Expires', 'StatusCode', 'StatusMessage', 'UserId', 'Language',\
+        \ 'SignatoryReminderStartDate', 'InitiatorEmailAddress', 'QueueCreated', 'QueueChanged'.\
+        \ Will default to 'SigningInstanceId' if not set. Will default to page 0 with\
+        \ a size of 10 if not set."
+      operationId: getSigningRequests
+      parameters:
+        - name: municipalityId
+          in: path
+          description: Municipality id
+          required: true
+          schema:
+            type: string
+          example: 2281
+        - name: pageable
+          in: query
+          required: true
+          schema:
+            $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SigningsResponse"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Problem"
+                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+    post:
+      tags:
+        - Signings
+      summary: Create Signing instance.
+      operationId: createSigningRequest
+      parameters:
+        - name: municipalityId
+          in: path
+          description: Municipality id
+          required: true
+          schema:
+            type: string
+          example: 2281
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SigningRequest"
+        required: true
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateSigningResponse"
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Problem"
+                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/signings/{signingId}:
+    get:
+      tags:
+        - Signings
+      summary: Get a signing request.
+      operationId: getSigningRequest
+      parameters:
+        - name: municipalityId
+          in: path
+          description: Municipality id
+          required: true
+          schema:
+            type: string
+          example: 2281
+        - name: signingId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SigningInstance"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Problem"
+                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+    patch:
+      tags:
+        - Signings
+      summary: Update a signing instance.
+      operationId: updateSigningRequest
+      parameters:
+        - name: municipalityId
+          in: path
+          description: Municipality id
+          required: true
+          schema:
+            type: string
+          example: 2281
+        - name: signingId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSigningRequest"
+        required: true
+      responses:
+        "204":
+          description: Successful operation
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Problem"
+                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "409":
+          description: Conflict
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "500":
+          description: Internal Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/signings/{signingId}/signatory/{partyId}:
+    get:
+      tags:
+        - Signings
+      summary: Get information about the current signatory
+      operationId: getSignatory
+      parameters:
+        - name: municipalityId
+          in: path
+          description: Municipality id
+          required: true
+          schema:
+            type: string
+          example: 2281
+        - name: signingId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: partyId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Signatory"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/Problem"
+                  - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /api-docs:
+    get:
+      tags:
+        - API
+      summary: OpenAPI
+      operationId: getApiDocs
+      responses:
+        "200":
+          description: OK
+          content:
+            application/yaml:
+              schema:
+                type: string
+      x-auth-type: None
+      x-throttling-tier: Unlimited
+      x-wso2-mutual-ssl: Optional
+components:
+  schemas:
+    Document:
+      type: object
+      properties:
+        name:
+          type:
+            - string
+            - "null"
+          description: The Document Name visible to the user in the signing process.
+          examples:
+            - Business Contract
+        fileName:
+          type: string
+          description: "The document file name including extension,"
+          examples:
+            - document.pdf
+          minLength: 1
+        mimeType:
+          type: string
+          description: The documents mimetype. Must be application/pdf
+          examples:
+            - application/pdf
+        content:
+          type: string
+          format: byte
+          description: Base64-encoded file (plain text)
+          examples:
+            - dGVzdA==
+      required:
+        - fileName
+    Identification:
+      type: object
+      description: The means of identification to use to identify the signatories.
+      properties:
+        alias:
+          type: string
+          description: |
+            Possible values for Alias type:
+            • SmsCode – One Time Password via SMS
+            • EmailCode – One Time Password via Email
+            • SvensktEId – Swedish e-identification (Swedish BankID)
+          examples:
+            - SmsCode
+    NotificationMessage:
+      type: object
+      description: Custom message for the signature request emails.
+      properties:
+        subject:
+          type: string
+          description: The subject of the notification message
+          examples:
+            - Please sign the document
+        body:
+          type: string
+          description: The body of the notification message
+          examples:
+            - "Dear John Doe, please sign the document."
+        language:
+          type: string
+          description: The language of the notification message.
+          examples:
+            - sv-SE
+          minLength: 1
+      required:
+        - language
+    Party:
+      type: object
+      description: A party related to the signing process.
+      properties:
+        name:
+          type: string
+          description: The name of the party
+          examples:
+            - John Doe
+        partyId:
+          type: string
+          description: The party id
+          examples:
+            - 550e8400-e29b-41d4-a716-446655440000
+        notificationMessage:
+          $ref: "#/components/schemas/NotificationMessage"
+          description: Custom message for the signature request emails for the specific
+            party. Overwrites the message in the Signing Request.
+        title:
+          type: string
+          description: The party title
+          examples:
+            - CEO
+        email:
+          type: string
+          description: The party email
+          examples:
+            - john.doe@sundsvall.se
+        phoneNumber:
+          type: string
+          description: The party phone number
+          examples:
+            - "0701740605"
+        organization:
+          type: string
+          description: The organization of the party.
+          examples:
+            - Sundsvall Municipality
+        language:
+          type: string
+          description: Language parameter that overwrites the language of the Signing
+            Instance for the current party.
+          examples:
+            - sv
+      required:
+        - email
+    Reminder:
+      type: object
+      description: A reminder for a signature request.
+      properties:
+        message:
+          $ref: "#/components/schemas/NotificationMessage"
+          description: The message of the reminder
+        enabled:
+          type: boolean
+          description: If the reminder is enabled
+          examples:
+            - "true"
+        intervalInHours:
+          type: integer
+          format: int32
+          description: The interval in hours between each reminder
+          examples:
+            - 24
+        startDateTime:
+          type: string
+          format: date-time
+          description: The date and time when the first reminder should be sent.
+          examples:
+            - 2026-11-22T15:30:00+02:00
+      required:
+        - enabled
+        - intervalInHours
+    Signatory:
+      type: object
+      description: A Signatory related to the signing process.
+      properties:
+        name:
+          type: string
+          description: The name of the party
+          examples:
+            - John Doe
+        partyId:
+          type: string
+          description: The party id
+          examples:
+            - 550e8400-e29b-41d4-a716-446655440000
+        notificationMessage:
+          $ref: "#/components/schemas/NotificationMessage"
+          description: Custom message for the signature request emails for the specific
+            party. Overwrites the message in the Signing Request.
+        title:
+          type: string
+          description: The party title
+          examples:
+            - CEO
+        email:
+          type: string
+          description: The party email
+          examples:
+            - john.doe@sundsvall.se
+        phoneNumber:
+          type: string
+          description: The party phone number
+          examples:
+            - "0701740605"
+        organization:
+          type: string
+          description: The organization of the party.
+          examples:
+            - Sundsvall Municipality
+        language:
+          type: string
+          description: Language parameter that overwrites the language of the Signing
+            Instance for the current party.
+          examples:
+            - sv
+        identifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/Identification"
+          minItems: 1
+      required:
+        - email
+        - identifications
+    SigningRequest:
+      type: object
+      description: The signing request.
+      properties:
+        additionalDocuments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Document"
+            description: Additional documents to sign.
+        language:
+          type: string
+          description: The language of the signing process.
+          examples:
+            - sv-SE
+        customerReference:
+          type: string
+          description: The customer reference
+          examples:
+            - "1234567890"
+        expires:
+          type: string
+          format: date-time
+          description: The date and time when the signing request expires.
+          examples:
+            - 2026-11-22T15:30:00+02:00
+        notificationMessage:
+          $ref: "#/components/schemas/NotificationMessage"
+          description: Custom message for the signature request emails.
+        reminder:
+          $ref: "#/components/schemas/Reminder"
+          description: A reminder for a signature request.
+        initiator:
+          $ref: "#/components/schemas/Party"
+          description: The initiator of the signing request.
+        additionalParties:
+          type: array
+          description: A party that is not part of the signing process but will get
+            a copy of the signed document when the signing instance is completed.
+          items:
+            $ref: "#/components/schemas/Party"
+        signatories:
+          type: array
+          description: The parties that will sign the documents.
+          items:
+            $ref: "#/components/schemas/Signatory"
+          minItems: 1
+        document:
+          $ref: "#/components/schemas/Document"
+          description: Information about the main document to sign.
+        flowType:
+          type: string
+          description: The flow type of the signing process.
+          examples:
+            - Sequential
+      required:
+        - document
+        - initiator
+        - signatories
+    Problem:
+      type: object
+      properties:
+        title:
+          type: string
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+        type:
+          type: string
+          format: uri
+        status:
+          type: integer
+          format: int32
+    ConstraintViolationProblem:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+        status:
+          type: integer
+          format: int32
+        violations:
+          type: array
+          items:
+            $ref: "#/components/schemas/Violation"
+        title:
+          type: string
+        detail:
+          type: string
+        causeAsProblem:
+          $ref: "#/components/schemas/ThrowableProblem"
+        instance:
+          type: string
+          format: uri
+    ThrowableProblem:
+      type: object
+      properties:
+        type:
+          type: string
+          format: uri
+        title:
+          type: string
+        status:
+          type: integer
+          format: int32
+        detail:
+          type: string
+        instance:
+          type: string
+          format: uri
+        causeAsProblem: { }
+    Violation:
+      type: object
+      properties:
+        field:
+          type: string
+        message:
+          type: string
+    CreateSigningResponse:
+      type: object
+      properties:
+        signingId:
+          type: string
+        signatoryUrls:
+          type: object
+          additionalProperties:
+            type: string
+    UpdateSigningRequest:
+      type: object
+      description: Request for updating a signing instance.
+      properties:
+        expires:
+          type: string
+          format: date-time
+          description: The date and time when the signing request expires.
+          examples:
+            - 2026-11-22T15:30:00+02:00
+        status:
+          type: string
+          description: The status of the signing instance.
+          examples:
+            - active
+            - withdrawn
+    Pageable:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+          minimum: 0
+        size:
+          type: integer
+          format: int32
+          minimum: 1
+        sort:
+          type: array
+          items:
+            type: string
+    Direction:
+      type: string
+      enum:
+        - ASC
+        - DESC
+    PagingAndSortingMetaData:
+      type: object
+      description: PagingAndSortingMetaData model
+      properties:
+        page:
+          type: integer
+          format: int32
+          description: Current page
+          examples:
+            - 5
+          readOnly: true
+        limit:
+          type: integer
+          format: int32
+          description: Displayed objects per page
+          examples:
+            - 20
+          readOnly: true
+        count:
+          type: integer
+          format: int32
+          description: Displayed objects on current page
+          examples:
+            - 13
+          readOnly: true
+        totalRecords:
+          type: integer
+          format: int64
+          description: Total amount of hits based on provided search parameters
+          examples:
+            - 98
+          readOnly: true
+        totalPages:
+          type: integer
+          format: int32
+          description: Total amount of pages based on provided search parameters
+          examples:
+            - 23
+          readOnly: true
+        sortBy:
+          type: array
+          items:
+            type: string
+            description: The properties to sort by
+            examples:
+              - property
+            readOnly: true
+        sortDirection:
+          $ref: "#/components/schemas/Direction"
+          description: The sort order direction
+          examples:
+            - ASC
+    SigningInstance:
+      type: object
+      description: The signing instance.
+      properties:
+        notificationMessages:
+          type: array
+          description: Custom message for the signature request emails.
+          items:
+            $ref: "#/components/schemas/NotificationMessage"
+        initiator:
+          $ref: "#/components/schemas/Party"
+          description: The initiator of the signing request.
+        additionalParties:
+          type: array
+          description: A party that is not part of the signing process but will get
+            a copy of the signed document when the signing instance is completed.
+          items:
+            $ref: "#/components/schemas/Party"
+        signatories:
+          type: array
+          description: The parties that will sign the documents.
+          items:
+            $ref: "#/components/schemas/Signatory"
+          minItems: 1
+        status:
+          $ref: "#/components/schemas/Status"
+          description: Status of the signing request.
+        customerReference:
+          type: string
+          description: The customer reference
+          examples:
+            - "1234567890"
+        created:
+          type: string
+          format: date-time
+          description: The date and time when the signing instance was created.
+          examples:
+            - 2026-04-02T11:20:00+02:00
+        changed:
+          type: string
+          format: date-time
+          description: The date and time when the signing instance was last changed.
+          examples:
+            - 2026-04-02T11:20:00+02:00
+        expires:
+          type: string
+          format: date-time
+          description: The date and time when the signing instance expires
+          examples:
+            - 2026-11-22T15:30:00+02:00
+        document:
+          $ref: "#/components/schemas/Document"
+          description: Information about the main document to sign.
+        signedDocument:
+          $ref: "#/components/schemas/Document"
+          description: Information about the signed document
+        additionalDocuments:
+          type: array
+          items:
+            $ref: "#/components/schemas/Document"
+            description: Additional documents to sign.
+        signingId:
+          type: string
+          description: The signing instance id.
+          examples:
+            - "1234567890"
+      required:
+        - initiator
+        - signatories
+    SigningsResponse:
+      type: object
+      description: Signing response.
+      properties:
+        signingInstances:
+          type: array
+          description: The signing instances.
+          items:
+            $ref: "#/components/schemas/SigningInstance"
+        _meta:
+          $ref: "#/components/schemas/PagingAndSortingMetaData"
+          readOnly: true
+    Status:
+      type: object
+      properties:
+        code:
+          type: string
+          description: The status code
+          examples:
+            - Created
+        message:
+          type: string
+          description: The status message
+          examples:
+            - The signing instance is halted.
+  securitySchemes: { }

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
@@ -1,0 +1,58 @@
+package se.sundsvall.esigning.integration.comfactfacade;
+
+import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.dept44.problem.Problem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@ExtendWith(MockitoExtension.class)
+class ComfactFacadeIntegrationTest {
+
+	@Mock
+	private ComfactFacadeClient mockClient;
+
+	@InjectMocks
+	private ComfactFacadeIntegration integration;
+
+	@Test
+	void createSigning() {
+		final var municipalityId = "2281";
+		final var request = new SigningRequest();
+		final var response = new CreateSigningResponse().signingId("123");
+		when(mockClient.createSigningRequest(anyString(), any())).thenReturn(response);
+
+		final var result = integration.createSigning(municipalityId, request);
+
+		assertThat(result).isEqualTo(response);
+		verify(mockClient).createSigningRequest(municipalityId, request);
+		verifyNoMoreInteractions(mockClient);
+	}
+
+	@Test
+	void createSigning_whenThrowsPropagatesProblem() {
+		final var municipalityId = "2281";
+		final var request = new SigningRequest();
+		when(mockClient.createSigningRequest(municipalityId, request)).thenThrow(Problem.valueOf(BAD_REQUEST, "Bad partyId"));
+
+		assertThatThrownBy(() -> integration.createSigning(municipalityId, request))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Bad Request: Bad partyId")
+			.hasFieldOrPropertyWithValue("status", BAD_REQUEST);
+
+		verify(mockClient).createSigningRequest(municipalityId, request);
+		verifyNoMoreInteractions(mockClient);
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeConfigurationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadeConfigurationTest.java
@@ -1,0 +1,74 @@
+package se.sundsvall.esigning.integration.comfactfacade.configuration;
+
+import feign.codec.ErrorDecoder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
+import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.esigning.integration.comfactfacade.configuration.ComfactFacadeConfiguration.CLIENT_ID;
+
+@ExtendWith(MockitoExtension.class)
+class ComfactFacadeConfigurationTest {
+
+	@Mock
+	private ClientRegistrationRepository clientRepositoryMock;
+
+	@Mock
+	private ClientRegistration clientRegistrationMock;
+
+	@Mock
+	private ComfactFacadeProperties propertiesMock;
+
+	@Spy
+	private FeignMultiCustomizer feignMultiCustomizerSpy;
+
+	@Captor
+	private ArgumentCaptor<ErrorDecoder> errorDecoderCaptor;
+
+	@InjectMocks
+	private ComfactFacadeConfiguration configuration;
+
+	@Test
+	void testFeignBuilderCustomizer() {
+		final var connectTimeout = 123;
+		final var readTimeout = 321;
+
+		when(propertiesMock.connectTimeout()).thenReturn(connectTimeout);
+		when(propertiesMock.readTimeout()).thenReturn(readTimeout);
+		when(clientRepositoryMock.findByRegistrationId(CLIENT_ID)).thenReturn(clientRegistrationMock);
+
+		try (MockedStatic<FeignMultiCustomizer> feignMultiCustomizerMock = Mockito.mockStatic(FeignMultiCustomizer.class)) {
+			feignMultiCustomizerMock.when(FeignMultiCustomizer::create).thenReturn(feignMultiCustomizerSpy);
+
+			configuration.feignBuilderCustomizer(clientRepositoryMock, propertiesMock);
+
+			feignMultiCustomizerMock.verify(FeignMultiCustomizer::create);
+		}
+
+		verify(propertiesMock).connectTimeout();
+		verify(propertiesMock).readTimeout();
+		verify(clientRepositoryMock).findByRegistrationId(CLIENT_ID);
+		verify(feignMultiCustomizerSpy).withErrorDecoder(errorDecoderCaptor.capture());
+		verify(feignMultiCustomizerSpy).withRequestTimeoutsInSeconds(connectTimeout, readTimeout);
+		verify(feignMultiCustomizerSpy).withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationMock);
+		verify(feignMultiCustomizerSpy).composeCustomizersToOne();
+
+		assertThat(errorDecoderCaptor.getValue())
+			.isInstanceOf(ProblemErrorDecoder.class)
+			.hasFieldOrPropertyWithValue("integrationName", CLIENT_ID);
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadePropertiesTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/configuration/ComfactFacadePropertiesTest.java
@@ -1,0 +1,24 @@
+package se.sundsvall.esigning.integration.comfactfacade.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.esigning.Application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
+
+@SpringBootTest(classes = Application.class, webEnvironment = MOCK)
+@ActiveProfiles("junit")
+class ComfactFacadePropertiesTest {
+
+	@Autowired
+	private ComfactFacadeProperties properties;
+
+	@Test
+	void testProperties() {
+		assertThat(properties.connectTimeout()).isEqualTo(5);
+		assertThat(properties.readTimeout()).isEqualTo(30);
+	}
+}


### PR DESCRIPTION
**Stacked PR 1/3** — e-signing provider-gateway rework (Postportalen e-signing).

Adds a Feign client to `api-comfact-facade`, generated from its OpenAPI contract, plus the integration wrapper, Feign configuration and properties (OAuth2 client-credentials, circuit breaker, retry).

- `contract/comfactfacade.yml` + `openapi-generator` execution → `generated.se.sundsvall.comfactfacade`
- `integration/comfactfacade/**` (client, integration, configuration, properties)
- comfact-facade OAuth2 + integration config for all profiles
- Integration/Configuration/Properties tests

Not yet wired to a caller — the provider abstraction (PR 2) consumes it. `mvn verify` green.

Follow-ups: **PR 2** provider abstraction, **PR 3** the `POST /signings` endpoint.