### PR TITLE
Add signing provider abstraction with Comfact implementation

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/model/SigningDocument.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/SigningDocument.java
@@ -4,21 +4,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 import se.sundsvall.dept44.common.validators.annotation.OneOf;
 import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
-@Getter
-@Setter
-@ToString
-@EqualsAndHashCode
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(setterPrefix = "with")
@@ -37,7 +31,7 @@ public class SigningDocument {
 	private String mimeType;
 
 	@NotBlank
-	@ValidBase64(nullable = true)
+	@ValidBase64
 	@Schema(description = "Base64-encoded content of the document to be signed", examples = "dGVzdA==", requiredMode = REQUIRED)
 	private String content;
 

--- a/src/main/java/se/sundsvall/esigning/api/model/SigningDocument.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/SigningDocument.java
@@ -1,0 +1,44 @@
+package se.sundsvall.esigning.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import se.sundsvall.dept44.common.validators.annotation.OneOf;
+import se.sundsvall.dept44.common.validators.annotation.ValidBase64;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+@Schema(description = "Document to be signed")
+public class SigningDocument {
+
+	@Schema(description = "Optional descriptive name for the document, visible to the signatory", examples = "Employment contract", requiredMode = NOT_REQUIRED)
+	private String name;
+
+	@NotBlank
+	@Schema(description = "The document file name including extension", examples = "document.pdf", requiredMode = REQUIRED)
+	private String fileName;
+
+	@OneOf(value = "application/pdf", message = "The provided mime type is not valid. Only application/pdf is supported.")
+	@Schema(description = "The document mime type. Must be application/pdf", examples = "application/pdf", requiredMode = REQUIRED)
+	private String mimeType;
+
+	@NotBlank
+	@ValidBase64(nullable = true)
+	@Schema(description = "Base64-encoded content of the document to be signed", examples = "dGVzdA==", requiredMode = REQUIRED)
+	private String content;
+
+}

--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
@@ -1,0 +1,72 @@
+package se.sundsvall.esigning.api.model;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.util.Set;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+import se.sundsvall.dept44.common.validators.annotation.OneOf;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+@Schema(description = "Start signing request model")
+public class StartSigningRequest {
+
+	@OneOf(value = {
+		"de-DE", "nb-NO", "ru-RU", "zh-CN", "fi-FI", "uk-UA", "en-US", "sv-SE", "da-DK", "fr-FR"
+	}, message = "The provided language is not valid. Valid values are [de-DE, nb-NO, ru-RU, zh-CN, fi-FI, uk-UA, en-US, sv-SE, da-DK, fr-FR].", nullable = true)
+	@Schema(description = "The language used for the signing instance. Swedish will be used if no language is provided", examples = "sv-SE", requiredMode = NOT_REQUIRED)
+	private String language;
+
+	@Schema(description = "Optional callback url that is notified when the signing case reaches a terminal state", examples = "https://example.com/callback", requiredMode = NOT_REQUIRED)
+	private String callbackUrl;
+
+	@Future
+	@DateTimeFormat(iso = DATE_TIME)
+	@Schema(description = "Optional date and time when the signing request expires", examples = "2026-12-31T23:59:59Z", requiredMode = NOT_REQUIRED)
+	private OffsetDateTime expires;
+
+	@Valid
+	@NotNull
+	@Schema(description = "The document to sign", implementation = SigningDocument.class, requiredMode = REQUIRED)
+	private SigningDocument document;
+
+	@Valid
+	@NotNull
+	@Schema(description = "The initiator of the signing request", implementation = Initiator.class, requiredMode = REQUIRED)
+	private Initiator initiator;
+
+	@Valid
+	@NotNull
+	@Schema(description = "The notification message", implementation = Message.class, requiredMode = REQUIRED)
+	private Message notificationMessage;
+
+	@Valid
+	@Schema(description = "Reminder object", implementation = Reminder.class, requiredMode = NOT_REQUIRED)
+	private Reminder reminder;
+
+	@NotEmpty
+	@ArraySchema(schema = @Schema(implementation = Signatory.class), minItems = 1, uniqueItems = true)
+	private Set<@Valid Signatory> signatories;
+
+}

--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
@@ -10,11 +10,8 @@ import java.time.OffsetDateTime;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
 import se.sundsvall.dept44.common.validators.annotation.OneOf;
 
@@ -22,10 +19,7 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIR
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import static org.springframework.format.annotation.DateTimeFormat.ISO.DATE_TIME;
 
-@Getter
-@Setter
-@ToString
-@EqualsAndHashCode
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(setterPrefix = "with")
@@ -37,9 +31,6 @@ public class StartSigningRequest {
 	}, message = "The provided language is not valid. Valid values are [de-DE, nb-NO, ru-RU, zh-CN, fi-FI, uk-UA, en-US, sv-SE, da-DK, fr-FR].", nullable = true)
 	@Schema(description = "The language used for the signing instance. Swedish will be used if no language is provided", examples = "sv-SE", requiredMode = NOT_REQUIRED)
 	private String language;
-
-	@Schema(description = "Optional callback url that is notified when the signing case reaches a terminal state", examples = "https://example.com/callback", requiredMode = NOT_REQUIRED)
-	private String callbackUrl;
 
 	@Future
 	@DateTimeFormat(iso = DATE_TIME)

--- a/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
@@ -1,0 +1,26 @@
+package se.sundsvall.esigning.provider;
+
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.provider.model.SigningResult;
+
+/**
+ * Abstraction over an e-signing provider. A new provider is added by implementing this interface and registering it as
+ * a Spring component - no existing logic needs to change. The active provider per municipality is resolved by
+ * {@link SigningProviderRegistry}.
+ */
+public interface SigningProvider {
+
+	/**
+	 * @return the unique id of this provider (e.g. "comfact"), used for configuration-driven selection.
+	 */
+	String getId();
+
+	/**
+	 * Starts a signing process at the provider.
+	 *
+	 * @param  municipalityId the municipality the signing belongs to
+	 * @param  request        the signing request
+	 * @return                the provider-neutral result including the provider's case id and the normalized status
+	 */
+	SigningResult startSigning(String municipalityId, StartSigningRequest request);
+}

--- a/src/main/java/se/sundsvall/esigning/provider/SigningProviderRegistry.java
+++ b/src/main/java/se/sundsvall/esigning/provider/SigningProviderRegistry.java
@@ -1,0 +1,44 @@
+package se.sundsvall.esigning.provider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import se.sundsvall.dept44.problem.Problem;
+import se.sundsvall.esigning.provider.configuration.ProviderProperties;
+
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+/**
+ * Resolves the active {@link SigningProvider} for a municipality, based on {@link ProviderProperties}. All providers
+ * present on the classpath are auto-registered by their {@link SigningProvider#getId()}.
+ */
+@Component
+public class SigningProviderRegistry {
+
+	private static final String NO_PROVIDER_CONFIGURED = "No signing provider is configured for municipality %s";
+	private static final String PROVIDER_NOT_AVAILABLE = "Configured signing provider '%s' for municipality %s is not available";
+
+	private final ProviderProperties providerProperties;
+	private final Map<String, SigningProvider> providersById;
+
+	public SigningProviderRegistry(final ProviderProperties providerProperties, final List<SigningProvider> providers) {
+		this.providerProperties = providerProperties;
+		this.providersById = providers.stream().collect(Collectors.toMap(SigningProvider::getId, Function.identity()));
+	}
+
+	public SigningProvider resolve(final String municipalityId) {
+		final var providerId = Optional.ofNullable(providerProperties.byMunicipalityId())
+			.map(mapping -> mapping.get(municipalityId))
+			.orElseGet(providerProperties::defaultProvider);
+
+		if (providerId == null) {
+			throw Problem.valueOf(INTERNAL_SERVER_ERROR, NO_PROVIDER_CONFIGURED.formatted(municipalityId));
+		}
+
+		return Optional.ofNullable(providersById.get(providerId))
+			.orElseThrow(() -> Problem.valueOf(INTERNAL_SERVER_ERROR, PROVIDER_NOT_AVAILABLE.formatted(providerId, municipalityId)));
+	}
+}

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
@@ -1,0 +1,91 @@
+package se.sundsvall.esigning.provider.comfact;
+
+import generated.se.sundsvall.comfactfacade.Document;
+import generated.se.sundsvall.comfactfacade.Identification;
+import generated.se.sundsvall.comfactfacade.NotificationMessage;
+import generated.se.sundsvall.comfactfacade.Party;
+import generated.se.sundsvall.comfactfacade.Reminder;
+import generated.se.sundsvall.comfactfacade.Signatory;
+import generated.se.sundsvall.comfactfacade.SigningRequest;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import se.sundsvall.esigning.api.model.Initiator;
+import se.sundsvall.esigning.api.model.Message;
+import se.sundsvall.esigning.api.model.SigningDocument;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+
+/**
+ * Maps the provider-neutral API request to Comfact facade's generated request model.
+ */
+public final class ComfactSigningMapper {
+
+	static final String DEFAULT_LANGUAGE = "sv-SE";
+	static final String IDENTIFICATION_ALIAS = "SvensktEId"; // Swedish e-identification (BankID)
+
+	private ComfactSigningMapper() {}
+
+	public static SigningRequest toComfactSigningRequest(final StartSigningRequest request) {
+		final var language = Optional.ofNullable(request.getLanguage()).orElse(DEFAULT_LANGUAGE);
+
+		return new SigningRequest()
+			.language(language)
+			.expires(request.getExpires())
+			.document(toDocument(request.getDocument()))
+			.initiator(toInitiator(request.getInitiator()))
+			.notificationMessage(toNotificationMessage(request.getNotificationMessage(), language))
+			.reminder(toReminder(request.getReminder(), language))
+			.signatories(toSignatories(request, language));
+	}
+
+	static Document toDocument(final SigningDocument document) {
+		return new Document()
+			.name(document.getName())
+			.fileName(document.getFileName())
+			.mimeType(document.getMimeType())
+			.content(Base64.getDecoder().decode(document.getContent()));
+	}
+
+	static Party toInitiator(final Initiator initiator) {
+		return new Party()
+			.name(initiator.getName())
+			.partyId(initiator.getPartyId())
+			.organization(initiator.getOrganization())
+			.email(initiator.getEmail());
+	}
+
+	static List<Signatory> toSignatories(final StartSigningRequest request, final String language) {
+		return request.getSignatories().stream()
+			.map(signatory -> toSignatory(signatory, language))
+			.toList();
+	}
+
+	static Signatory toSignatory(final se.sundsvall.esigning.api.model.Signatory signatory, final String language) {
+		return new Signatory()
+			.name(signatory.getName())
+			.partyId(signatory.getPartyId())
+			.organization(signatory.getOrganization())
+			.email(signatory.getEmail())
+			.notificationMessage(toNotificationMessage(signatory.getNotificationMessage(), language))
+			.identifications(List.of(new Identification().alias(IDENTIFICATION_ALIAS)));
+	}
+
+	static NotificationMessage toNotificationMessage(final Message message, final String language) {
+		return Optional.ofNullable(message)
+			.map(m -> new NotificationMessage()
+				.subject(m.getSubject())
+				.body(m.getBody())
+				.language(language))
+			.orElse(null);
+	}
+
+	static Reminder toReminder(final se.sundsvall.esigning.api.model.Reminder reminder, final String language) {
+		return Optional.ofNullable(reminder)
+			.map(r -> new Reminder()
+				.enabled(true)
+				.intervalInHours(r.getIntervalInHours())
+				.startDateTime(r.getStartDateTime())
+				.message(toNotificationMessage(r.getMessage(), language)))
+			.orElse(null);
+	}
+}

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
@@ -1,0 +1,42 @@
+package se.sundsvall.esigning.provider.comfact;
+
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.integration.comfactfacade.ComfactFacadeIntegration;
+import se.sundsvall.esigning.provider.SigningProvider;
+import se.sundsvall.esigning.provider.model.SigningResult;
+
+import static java.util.Collections.emptyMap;
+import static se.sundsvall.esigning.provider.comfact.ComfactSigningMapper.toComfactSigningRequest;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
+
+/**
+ * Reference {@link SigningProvider} implementation backed by Comfact (via api-comfact-facade).
+ */
+@Component
+public class ComfactSigningProvider implements SigningProvider {
+
+	public static final String PROVIDER_ID = "comfact";
+
+	private final ComfactFacadeIntegration comfactFacadeIntegration;
+
+	public ComfactSigningProvider(final ComfactFacadeIntegration comfactFacadeIntegration) {
+		this.comfactFacadeIntegration = comfactFacadeIntegration;
+	}
+
+	@Override
+	public String getId() {
+		return PROVIDER_ID;
+	}
+
+	@Override
+	public SigningResult startSigning(final String municipalityId, final StartSigningRequest request) {
+		final var response = comfactFacadeIntegration.createSigning(municipalityId, toComfactSigningRequest(request));
+
+		return new SigningResult(
+			response.getSigningId(),
+			INITIERAT,
+			Optional.ofNullable(response.getSignatoryUrls()).orElse(emptyMap()));
+	}
+}

--- a/src/main/java/se/sundsvall/esigning/provider/configuration/ProviderProperties.java
+++ b/src/main/java/se/sundsvall/esigning/provider/configuration/ProviderProperties.java
@@ -1,0 +1,14 @@
+package se.sundsvall.esigning.provider.configuration;
+
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration of which signing provider a given municipality (organization) uses.
+ *
+ * @param defaultProvider  the provider id to use when no municipality-specific mapping exists
+ * @param byMunicipalityId provider id keyed by municipality id, e.g. {@code {"2281": "comfact"}}
+ */
+@ConfigurationProperties("esigning.provider")
+public record ProviderProperties(String defaultProvider, Map<String, String> byMunicipalityId) {
+}

--- a/src/main/java/se/sundsvall/esigning/provider/model/SigningResult.java
+++ b/src/main/java/se/sundsvall/esigning/provider/model/SigningResult.java
@@ -1,0 +1,13 @@
+package se.sundsvall.esigning.provider.model;
+
+import java.util.Map;
+
+/**
+ * Provider-neutral result of starting a signing process.
+ *
+ * @param providerCaseId the signing provider's own case/instance id
+ * @param status         the normalized status of the signing case
+ * @param signatoryUrls  direct signing urls per party id, when the provider supplies them
+ */
+public record SigningResult(String providerCaseId, SigningStatus status, Map<String, String> signatoryUrls) {
+}

--- a/src/main/java/se/sundsvall/esigning/provider/model/SigningStatus.java
+++ b/src/main/java/se/sundsvall/esigning/provider/model/SigningStatus.java
@@ -1,0 +1,13 @@
+package se.sundsvall.esigning.provider.model;
+
+/**
+ * Provider-neutral, normalized signing status. Provider-specific status vocabularies (e.g. Comfact's) are mapped to
+ * this set so that consumers and future providers are decoupled from any single provider's terminology.
+ */
+public enum SigningStatus {
+	INITIERAT,
+	INVANTAR_SIGNERING,
+	SIGNERAT,
+	UTGANGET,
+	FEL
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,12 @@ spring:
             provider: comfactfacade
             client-id: ${config.comfactfacade.client-id}
             client-secret: ${config.comfactfacade.client-secret}
+esigning:
+  provider:
+    # Active signing provider per organization (municipality id). Falls back to default-provider when unmapped.
+    default-provider: comfact
+    by-municipality-id:
+      "2281": comfact
 integration:
   esigningprocess:
     connect-timeout: ${config.esigningprocess.connect-timeout}

--- a/src/test/java/se/sundsvall/esigning/TestUtil.java
+++ b/src/test/java/se/sundsvall/esigning/TestUtil.java
@@ -11,7 +11,9 @@ import se.sundsvall.esigning.api.model.Initiator;
 import se.sundsvall.esigning.api.model.Message;
 import se.sundsvall.esigning.api.model.Reminder;
 import se.sundsvall.esigning.api.model.Signatory;
+import se.sundsvall.esigning.api.model.SigningDocument;
 import se.sundsvall.esigning.api.model.SigningRequest;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
 
 public final class TestUtil {
 
@@ -132,6 +134,44 @@ public final class TestUtil {
 
 	public static EsigningResponse createEsigningResponse() {
 		return createEsigningResponse(null);
+	}
+
+	public static SigningDocument createSigningDocument(final Consumer<SigningDocument> modifier) {
+		final var bean = SigningDocument.builder()
+			.withName("descriptiveName")
+			.withFileName("test.pdf")
+			.withMimeType("application/pdf")
+			.withContent("dGVzdA==")
+			.build();
+
+		Optional.ofNullable(modifier).ifPresent(m -> m.accept(bean));
+
+		return bean;
+	}
+
+	public static SigningDocument createSigningDocument() {
+		return createSigningDocument(null);
+	}
+
+	public static StartSigningRequest createStartSigningRequest(final Consumer<StartSigningRequest> modifier) {
+		final var bean = StartSigningRequest.builder()
+			.withExpires(OffsetDateTime.now().plusDays(1))
+			.withLanguage("sv-SE")
+			.withCallbackUrl("callbackUrl")
+			.withNotificationMessage(createMessage())
+			.withInitiator(createInitiator())
+			.withReminder(createReminder())
+			.withSignatories(Set.of(createSignatory()))
+			.withDocument(createSigningDocument())
+			.build();
+
+		Optional.ofNullable(modifier).ifPresent(m -> m.accept(bean));
+
+		return bean;
+	}
+
+	public static StartSigningRequest createStartSigningRequest() {
+		return createStartSigningRequest(null);
 	}
 
 }

--- a/src/test/java/se/sundsvall/esigning/TestUtil.java
+++ b/src/test/java/se/sundsvall/esigning/TestUtil.java
@@ -157,7 +157,6 @@ public final class TestUtil {
 		final var bean = StartSigningRequest.builder()
 			.withExpires(OffsetDateTime.now().plusDays(1))
 			.withLanguage("sv-SE")
-			.withCallbackUrl("callbackUrl")
 			.withNotificationMessage(createMessage())
 			.withInitiator(createInitiator())
 			.withReminder(createReminder())

--- a/src/test/java/se/sundsvall/esigning/api/model/SigningDocumentTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/SigningDocumentTest.java
@@ -1,0 +1,52 @@
+package se.sundsvall.esigning.api.model;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+
+class SigningDocumentTest {
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(SigningDocument.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builderTest() {
+		final var name = "name";
+		final var fileName = "document.pdf";
+		final var mimeType = "application/pdf";
+		final var content = "dGVzdA==";
+
+		final var bean = SigningDocument.builder()
+			.withName(name)
+			.withFileName(fileName)
+			.withMimeType(mimeType)
+			.withContent(content)
+			.build();
+
+		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
+		assertThat(bean.getName()).isEqualTo(name);
+		assertThat(bean.getFileName()).isEqualTo(fileName);
+		assertThat(bean.getMimeType()).isEqualTo(mimeType);
+		assertThat(bean.getContent()).isEqualTo(content);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(SigningDocument.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new SigningDocument()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
@@ -42,7 +42,6 @@ class StartSigningRequestTest {
 	void builderTest() {
 		final var expires = OffsetDateTime.now();
 		final var language = "sv-SE";
-		final var callbackUrl = "callbackUrl";
 		final var reminder = createReminder();
 		final var signatories = Set.of(createSignatory());
 		final var message = createMessage();
@@ -53,7 +52,6 @@ class StartSigningRequestTest {
 			.withExpires(expires)
 			.withDocument(document)
 			.withLanguage(language)
-			.withCallbackUrl(callbackUrl)
 			.withReminder(reminder)
 			.withSignatories(signatories)
 			.withNotificationMessage(message)
@@ -61,7 +59,6 @@ class StartSigningRequestTest {
 			.build();
 
 		assertThat(bean).satisfies(b -> {
-			assertThat(b.getCallbackUrl()).isEqualTo(callbackUrl);
 			assertThat(b.getExpires()).isEqualTo(expires);
 			assertThat(b.getLanguage()).isEqualTo(language);
 			assertThat(b.getReminder()).isEqualTo(reminder);

--- a/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
@@ -1,0 +1,80 @@
+package se.sundsvall.esigning.api.model;
+
+import com.google.code.beanmatchers.BeanMatchers;
+import java.time.OffsetDateTime;
+import java.util.Random;
+import java.util.Set;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static se.sundsvall.esigning.TestUtil.createInitiator;
+import static se.sundsvall.esigning.TestUtil.createMessage;
+import static se.sundsvall.esigning.TestUtil.createReminder;
+import static se.sundsvall.esigning.TestUtil.createSignatory;
+import static se.sundsvall.esigning.TestUtil.createSigningDocument;
+
+class StartSigningRequestTest {
+
+	@BeforeAll
+	static void setup() {
+		BeanMatchers.registerValueGenerator(() -> OffsetDateTime.now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+	}
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(StartSigningRequest.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builderTest() {
+		final var expires = OffsetDateTime.now();
+		final var language = "sv-SE";
+		final var callbackUrl = "callbackUrl";
+		final var reminder = createReminder();
+		final var signatories = Set.of(createSignatory());
+		final var message = createMessage();
+		final var initiator = createInitiator();
+		final var document = createSigningDocument();
+
+		final var bean = StartSigningRequest.builder()
+			.withExpires(expires)
+			.withDocument(document)
+			.withLanguage(language)
+			.withCallbackUrl(callbackUrl)
+			.withReminder(reminder)
+			.withSignatories(signatories)
+			.withNotificationMessage(message)
+			.withInitiator(initiator)
+			.build();
+
+		assertThat(bean).satisfies(b -> {
+			assertThat(b.getCallbackUrl()).isEqualTo(callbackUrl);
+			assertThat(b.getExpires()).isEqualTo(expires);
+			assertThat(b.getLanguage()).isEqualTo(language);
+			assertThat(b.getReminder()).isEqualTo(reminder);
+			assertThat(b.getSignatories()).isEqualTo(signatories);
+			assertThat(b.getNotificationMessage()).isEqualTo(message);
+			assertThat(b.getInitiator()).isEqualTo(initiator);
+			assertThat(b.getDocument()).isEqualTo(document);
+		}).hasNoNullFieldsOrProperties();
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(StartSigningRequest.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new StartSigningRequest()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
@@ -1,0 +1,75 @@
+package se.sundsvall.esigning.provider;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import se.sundsvall.dept44.problem.Problem;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.provider.configuration.ProviderProperties;
+import se.sundsvall.esigning.provider.model.SigningResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+class SigningProviderRegistryTest {
+
+	private static final SigningProvider COMFACT = new TestProvider("comfact");
+	private static final SigningProvider OTHER = new TestProvider("other");
+
+	@Test
+	void resolveByMunicipalityMapping() {
+		final var registry = new SigningProviderRegistry(new ProviderProperties("other", Map.of("2281", "comfact")), List.of(COMFACT, OTHER));
+
+		assertThat(registry.resolve("2281")).isSameAs(COMFACT);
+	}
+
+	@Test
+	void resolveFallsBackToDefault() {
+		final var registry = new SigningProviderRegistry(new ProviderProperties("other", Map.of("2281", "comfact")), List.of(COMFACT, OTHER));
+
+		assertThat(registry.resolve("1984")).isSameAs(OTHER);
+	}
+
+	@Test
+	void resolveFallsBackToDefaultWhenMappingIsNull() {
+		final var registry = new SigningProviderRegistry(new ProviderProperties("comfact", null), List.of(COMFACT));
+
+		assertThat(registry.resolve("2281")).isSameAs(COMFACT);
+	}
+
+	@Test
+	void resolveThrowsWhenNoProviderConfigured() {
+		final var registry = new SigningProviderRegistry(new ProviderProperties(null, Map.of()), List.of(COMFACT));
+
+		assertThatThrownBy(() -> registry.resolve("2281"))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Internal Server Error: No signing provider is configured for municipality 2281")
+			.hasFieldOrPropertyWithValue("status", INTERNAL_SERVER_ERROR);
+	}
+
+	@Test
+	void resolveThrowsWhenConfiguredProviderMissing() {
+		final var registry = new SigningProviderRegistry(new ProviderProperties("missing", Map.of()), List.of(COMFACT));
+
+		assertThatThrownBy(() -> registry.resolve("2281"))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Internal Server Error: Configured signing provider 'missing' for municipality 2281 is not available")
+			.hasFieldOrPropertyWithValue("status", INTERNAL_SERVER_ERROR);
+	}
+
+	private record TestProvider(String id)
+		implements
+		SigningProvider {
+
+		@Override
+		public String getId() {
+			return id;
+		}
+
+		@Override
+		public SigningResult startSigning(final String municipalityId, final StartSigningRequest request) {
+			return null;
+		}
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
@@ -1,0 +1,64 @@
+package se.sundsvall.esigning.provider.comfact;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+
+class ComfactSigningMapperTest {
+
+	@Test
+	void toComfactSigningRequest() {
+		final var request = createStartSigningRequest();
+		final var signatory = request.getSignatories().iterator().next();
+
+		final var result = ComfactSigningMapper.toComfactSigningRequest(request);
+
+		assertThat(result.getLanguage()).isEqualTo("sv-SE");
+		assertThat(result.getExpires()).isEqualTo(request.getExpires());
+
+		assertThat(result.getNotificationMessage()).isNotNull();
+		assertThat(result.getNotificationMessage().getSubject()).isEqualTo(request.getNotificationMessage().getSubject());
+		assertThat(result.getNotificationMessage().getBody()).isEqualTo(request.getNotificationMessage().getBody());
+		assertThat(result.getNotificationMessage().getLanguage()).isEqualTo("sv-SE");
+
+		assertThat(result.getInitiator()).isNotNull();
+		assertThat(result.getInitiator().getName()).isEqualTo(request.getInitiator().getName());
+		assertThat(result.getInitiator().getPartyId()).isEqualTo(request.getInitiator().getPartyId());
+		assertThat(result.getInitiator().getEmail()).isEqualTo(request.getInitiator().getEmail());
+
+		assertThat(result.getReminder()).isNotNull();
+		assertThat(result.getReminder().getEnabled()).isTrue();
+		assertThat(result.getReminder().getIntervalInHours()).isEqualTo(request.getReminder().getIntervalInHours());
+		assertThat(result.getReminder().getStartDateTime()).isEqualTo(request.getReminder().getStartDateTime());
+
+		assertThat(result.getDocument()).isNotNull();
+		assertThat(result.getDocument().getName()).isEqualTo(request.getDocument().getName());
+		assertThat(result.getDocument().getFileName()).isEqualTo("test.pdf");
+		assertThat(result.getDocument().getMimeType()).isEqualTo("application/pdf");
+		assertThat(result.getDocument().getContent()).isEqualTo("test".getBytes(StandardCharsets.UTF_8));
+
+		assertThat(result.getSignatories()).hasSize(1);
+		final var mappedSignatory = result.getSignatories().getFirst();
+		assertThat(mappedSignatory.getName()).isEqualTo(signatory.getName());
+		assertThat(mappedSignatory.getPartyId()).isEqualTo(signatory.getPartyId());
+		assertThat(mappedSignatory.getEmail()).isEqualTo(signatory.getEmail());
+		assertThat(mappedSignatory.getIdentifications()).hasSize(1);
+		assertThat(mappedSignatory.getIdentifications().getFirst().getAlias()).isEqualTo(ComfactSigningMapper.IDENTIFICATION_ALIAS);
+	}
+
+	@Test
+	void toComfactSigningRequest_defaultsLanguageAndOmitsNullReminder() {
+		final var request = createStartSigningRequest(r -> {
+			r.setLanguage(null);
+			r.setReminder(null);
+		});
+
+		final var result = ComfactSigningMapper.toComfactSigningRequest(request);
+
+		assertThat(result.getLanguage()).isEqualTo(ComfactSigningMapper.DEFAULT_LANGUAGE);
+		assertThat(result.getNotificationMessage().getLanguage()).isEqualTo(ComfactSigningMapper.DEFAULT_LANGUAGE);
+		assertThat(result.getReminder()).isNull();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
@@ -1,0 +1,72 @@
+package se.sundsvall.esigning.provider.comfact;
+
+import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningRequest;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.esigning.integration.comfactfacade.ComfactFacadeIntegration;
+import se.sundsvall.esigning.provider.model.SigningStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ComfactSigningProviderTest {
+
+	@Mock
+	private ComfactFacadeIntegration mockIntegration;
+
+	@InjectMocks
+	private ComfactSigningProvider provider;
+
+	@Captor
+	private ArgumentCaptor<SigningRequest> requestCaptor;
+
+	@Test
+	void getId() {
+		assertThat(provider.getId()).isEqualTo("comfact");
+	}
+
+	@Test
+	void startSigning() {
+		final var municipalityId = "2281";
+		final var request = createStartSigningRequest();
+		final var signatoryUrls = Map.of("550e8400-e29b-41d4-a716-446655440000", "https://sign.example/abc");
+		when(mockIntegration.createSigning(eq(municipalityId), any(SigningRequest.class)))
+			.thenReturn(new CreateSigningResponse().signingId("comfact-123").signatoryUrls(signatoryUrls));
+
+		final var result = provider.startSigning(municipalityId, request);
+
+		assertThat(result.providerCaseId()).isEqualTo("comfact-123");
+		assertThat(result.status()).isEqualTo(SigningStatus.INITIERAT);
+		assertThat(result.signatoryUrls()).isEqualTo(signatoryUrls);
+
+		verify(mockIntegration).createSigning(eq(municipalityId), requestCaptor.capture());
+		assertThat(requestCaptor.getValue().getDocument().getFileName()).isEqualTo("test.pdf");
+		assertThat(requestCaptor.getValue().getSignatories()).hasSize(1);
+		verifyNoMoreInteractions(mockIntegration);
+	}
+
+	@Test
+	void startSigning_nullSignatoryUrlsDefaultsToEmptyMap() {
+		final var municipalityId = "2281";
+		final var request = createStartSigningRequest();
+		when(mockIntegration.createSigning(eq(municipalityId), any(SigningRequest.class)))
+			.thenReturn(new CreateSigningResponse().signingId("comfact-123").signatoryUrls(null));
+
+		final var result = provider.startSigning(municipalityId, request);
+
+		assertThat(result.signatoryUrls()).isEmpty();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/provider/configuration/ProviderPropertiesTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/configuration/ProviderPropertiesTest.java
@@ -1,0 +1,24 @@
+package se.sundsvall.esigning.provider.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.esigning.Application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.MOCK;
+
+@SpringBootTest(classes = Application.class, webEnvironment = MOCK)
+@ActiveProfiles("junit")
+class ProviderPropertiesTest {
+
+	@Autowired
+	private ProviderProperties properties;
+
+	@Test
+	void testProperties() {
+		assertThat(properties.defaultProvider()).isEqualTo("comfact");
+		assertThat(properties.byMunicipalityId()).containsEntry("2281", "comfact");
+	}
+}


### PR DESCRIPTION
**Stacked PR 2/3** — builds on #46.

Adds the provider abstraction that lets each organization use a configurable signing provider (Story: driftansvarig).

- `SigningProvider` SPI + `SigningProviderRegistry` (config-driven per municipality via `esigning.provider.by-municipality-id`, default `comfact`)
- `ComfactSigningProvider` + `ComfactSigningMapper` (reference impl over the comfact-facade client from #46; signatory identification defaults to `SvensktEId`/BankID)
- `provider/model/{SigningStatus,SigningResult}`, `StartSigningRequest`/`SigningDocument` API models
- Registry/provider/mapper/properties/model tests

Adding a new provider = one `@Component implements SigningProvider` + one YAML line, no existing-logic change. Not yet exposed via an endpoint — PR 3 adds `POST /signings`. `mvn verify` green.