### PR TITLE
Add POST /signings endpoint to create a signing request

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
+++ b/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
@@ -1,0 +1,58 @@
+package se.sundsvall.esigning.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
+import se.sundsvall.dept44.problem.Problem;
+import se.sundsvall.dept44.problem.violations.ConstraintViolationProblem;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.api.model.StartSigningResponse;
+import se.sundsvall.esigning.service.SigningGatewayService;
+
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.status;
+
+@RestController
+@Validated
+@RequestMapping("/{municipalityId}/e-signing")
+@ApiResponses(value = {
+	@ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = APPLICATION_JSON_VALUE), useReturnTypeSchema = true),
+	@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(oneOf = {
+		Problem.class, ConstraintViolationProblem.class
+	}))),
+	@ApiResponse(responseCode = "500", description = "Internal Server Error", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class))),
+	@ApiResponse(responseCode = "502", description = "Bad Gateway", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+})
+@Tag(name = "eSigning", description = "E-signing")
+class SigningGatewayResource {
+
+	private final SigningGatewayService signingGatewayService;
+
+	SigningGatewayResource(final SigningGatewayService signingGatewayService) {
+		this.signingGatewayService = signingGatewayService;
+	}
+
+	@Operation(summary = "Create a signing request via the configured signing provider")
+	@PostMapping(value = "/signings", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+	ResponseEntity<StartSigningResponse> createSigning(
+		@PathVariable @Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId final String municipalityId,
+		@Valid @RequestBody final StartSigningRequest request) {
+		return status(CREATED).body(signingGatewayService.startSigning(municipalityId, request));
+	}
+
+}

--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningResponse.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningResponse.java
@@ -4,16 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
-@EqualsAndHashCode
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(setterPrefix = "with")

--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningResponse.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningResponse.java
@@ -1,0 +1,37 @@
+package se.sundsvall.esigning.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+@Schema(description = "Start signing response model")
+public class StartSigningResponse {
+
+	@Schema(description = "The signing provider's case id", examples = "1234567890")
+	private String providerCaseId;
+
+	@Schema(description = "The normalized status of the signing case", examples = "INITIERAT", allowableValues = {
+		"INITIERAT", "INVANTAR_SIGNERING", "SIGNERAT", "UTGANGET", "FEL"
+	})
+	private String status;
+
+	@Schema(description = "The id of the signing provider that handled the request", examples = "comfact")
+	private String provider;
+
+	@Schema(description = "Direct signing urls per party id, when supplied by the provider")
+	private Map<String, String> signatoryUrls;
+
+}

--- a/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
+++ b/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
@@ -1,0 +1,33 @@
+package se.sundsvall.esigning.service;
+
+import org.springframework.stereotype.Service;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.api.model.StartSigningResponse;
+import se.sundsvall.esigning.provider.SigningProvider;
+import se.sundsvall.esigning.provider.SigningProviderRegistry;
+
+/**
+ * Entry point for the provider-agnostic signing flow. Selects the configured provider for the municipality and
+ * delegates the (synchronous) start of the signing process to it.
+ */
+@Service
+public class SigningGatewayService {
+
+	private final SigningProviderRegistry signingProviderRegistry;
+
+	public SigningGatewayService(final SigningProviderRegistry signingProviderRegistry) {
+		this.signingProviderRegistry = signingProviderRegistry;
+	}
+
+	public StartSigningResponse startSigning(final String municipalityId, final StartSigningRequest request) {
+		final SigningProvider provider = signingProviderRegistry.resolve(municipalityId);
+		final var result = provider.startSigning(municipalityId, request);
+
+		return StartSigningResponse.builder()
+			.withProviderCaseId(result.providerCaseId())
+			.withStatus(result.status().name())
+			.withProvider(provider.getId())
+			.withSignatoryUrls(result.signatoryUrls())
+			.build();
+	}
+}

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:57283
+- url: http://localhost:58664
   description: Generated server url
 tags:
 - name: eSigning
@@ -415,12 +415,6 @@ components:
             used if no language is provided
           examples:
           - sv-SE
-        callbackUrl:
-          type: string
-          description: Optional callback url that is notified when the signing case
-            reaches a terminal state
-          examples:
-          - https://example.com/callback
         expires:
           type: string
           format: date-time

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:60399
+- url: http://localhost:57283
   description: Generated server url
 tags:
 - name: eSigning
@@ -56,6 +56,53 @@ paths:
                 $ref: "#/components/schemas/Problem"
         "503":
           description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/e-signing/signings:
+    post:
+      tags:
+      - eSigning
+      summary: Create a signing request via the configured signing provider
+      operationId: createSigning
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StartSigningRequest"
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StartSigningResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
           content:
             application/problem+json:
               schema:
@@ -287,10 +334,10 @@ components:
             $ref: "#/components/schemas/Violation"
         title:
           type: string
-        detail:
-          type: string
         causeAsProblem:
           $ref: "#/components/schemas/ThrowableProblem"
+        detail:
+          type: string
         instance:
           type: string
           format: uri
@@ -327,4 +374,110 @@ components:
           description: The process id of the esigning process
           examples:
           - "12345"
+    SigningDocument:
+      type: object
+      description: Document to be signed
+      properties:
+        name:
+          type: string
+          description: "Optional descriptive name for the document, visible to the\
+            \ signatory"
+          examples:
+          - Employment contract
+        fileName:
+          type: string
+          description: The document file name including extension
+          examples:
+          - document.pdf
+          minLength: 1
+        mimeType:
+          type: string
+          description: The document mime type. Must be application/pdf
+          examples:
+          - application/pdf
+        content:
+          type: string
+          description: Base64-encoded content of the document to be signed
+          examples:
+          - dGVzdA==
+          minLength: 1
+      required:
+      - content
+      - fileName
+      - mimeType
+    StartSigningRequest:
+      type: object
+      description: Start signing request model
+      properties:
+        language:
+          type: string
+          description: The language used for the signing instance. Swedish will be
+            used if no language is provided
+          examples:
+          - sv-SE
+        callbackUrl:
+          type: string
+          description: Optional callback url that is notified when the signing case
+            reaches a terminal state
+          examples:
+          - https://example.com/callback
+        expires:
+          type: string
+          format: date-time
+          description: Optional date and time when the signing request expires
+          examples:
+          - 2026-12-31T23:59:59Z
+        document:
+          $ref: "#/components/schemas/SigningDocument"
+          description: The document to sign
+        initiator:
+          $ref: "#/components/schemas/Initiator"
+          description: The initiator of the signing request
+        notificationMessage:
+          $ref: "#/components/schemas/Message"
+          description: The notification message
+        reminder:
+          $ref: "#/components/schemas/Reminder"
+          description: Reminder object
+        signatories:
+          type: array
+          items:
+            $ref: "#/components/schemas/Signatory"
+          minItems: 1
+          uniqueItems: true
+      required:
+      - document
+      - initiator
+      - notificationMessage
+      - signatories
+    StartSigningResponse:
+      type: object
+      description: Start signing response model
+      properties:
+        providerCaseId:
+          type: string
+          description: The signing provider's case id
+          examples:
+          - "1234567890"
+        status:
+          type: string
+          description: The normalized status of the signing case
+          enum:
+          - INITIERAT
+          - INVANTAR_SIGNERING
+          - SIGNERAT
+          - UTGANGET
+          - FEL
+          examples:
+          - INITIERAT
+        provider:
+          type: string
+          description: The id of the signing provider that handled the request
+          examples:
+          - comfact
+        signatoryUrls:
+          type: object
+          additionalProperties:
+            type: string
+          description: "Direct signing urls per party id, when supplied by the provider"
   securitySchemes: {}

--- a/src/test/java/se/sundsvall/esigning/TestUtil.java
+++ b/src/test/java/se/sundsvall/esigning/TestUtil.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning;
 
 import java.time.OffsetDateTime;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -14,6 +15,7 @@ import se.sundsvall.esigning.api.model.Signatory;
 import se.sundsvall.esigning.api.model.SigningDocument;
 import se.sundsvall.esigning.api.model.SigningRequest;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.api.model.StartSigningResponse;
 
 public final class TestUtil {
 
@@ -172,6 +174,23 @@ public final class TestUtil {
 
 	public static StartSigningRequest createStartSigningRequest() {
 		return createStartSigningRequest(null);
+	}
+
+	public static StartSigningResponse createStartSigningResponse(final Consumer<StartSigningResponse> modifier) {
+		final var bean = StartSigningResponse.builder()
+			.withProviderCaseId("1234567890")
+			.withStatus("INITIERAT")
+			.withProvider("comfact")
+			.withSignatoryUrls(Map.of("550e8400-e29b-41d4-a716-446655440000", "https://sign.example/abc"))
+			.build();
+
+		Optional.ofNullable(modifier).ifPresent(m -> m.accept(bean));
+
+		return bean;
+	}
+
+	public static StartSigningResponse createStartSigningResponse() {
+		return createStartSigningResponse(null);
 	}
 
 }

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
@@ -44,7 +44,6 @@ class SigningGatewayResourceFailureTest {
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setDocument(null)), "document", "must not be null"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setFileName(null)), "document.fileName", "must not be blank"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setMimeType("text/plain")), "document.mimeType", "The provided mime type is not valid. Only application/pdf is supported."),
-			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setContent(null)), "document.content", "must not be blank"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setContent("@@@@")), "document.content", "not a valid BASE64-encoded string"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setLanguage("invalid-language")), "language",
 				"The provided language is not valid. Valid values are [de-DE, nb-NO, ru-RU, zh-CN, fi-FI, uk-UA, en-US, sv-SE, da-DK, fr-FR]."),

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
@@ -1,0 +1,96 @@
+package se.sundsvall.esigning.api;
+
+import java.time.OffsetDateTime;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import se.sundsvall.dept44.problem.violations.ConstraintViolationProblem;
+import se.sundsvall.dept44.problem.violations.Violation;
+import se.sundsvall.esigning.Application;
+import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.service.SigningGatewayService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static se.sundsvall.esigning.TestUtil.createSignatory;
+import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+
+@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@ActiveProfiles("junit")
+@AutoConfigureWebTestClient
+class SigningGatewayResourceFailureTest {
+
+	@MockitoBean
+	private SigningGatewayService signingGatewayServiceMock;
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	private static Stream<Arguments> provideBadRequests() {
+		final var municipalityId = "2281";
+		return Stream.of(
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setDocument(null)), "document", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setFileName(null)), "document.fileName", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setMimeType("text/plain")), "document.mimeType", "The provided mime type is not valid. Only application/pdf is supported."),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setContent(null)), "document.content", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getDocument().setContent("@@@@")), "document.content", "not a valid BASE64-encoded string"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setLanguage("invalid-language")), "language",
+				"The provided language is not valid. Valid values are [de-DE, nb-NO, ru-RU, zh-CN, fi-FI, uk-UA, en-US, sv-SE, da-DK, fr-FR]."),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setExpires(OffsetDateTime.now().minusDays(3))), "expires", "must be a future date"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setInitiator(null)), "initiator", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getInitiator().setEmail(null)), "initiator.email", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getInitiator().setEmail("Not-a-valid-email")), "initiator.email", "must be a well-formed email address"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getInitiator().setName(null)), "initiator.name", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getInitiator().setPartyId("Not-a-valid-UUID")), "initiator.partyId", "not a valid UUID"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setNotificationMessage(null)), "notificationMessage", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getNotificationMessage().setBody(null)), "notificationMessage.body", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getNotificationMessage().setSubject(null)), "notificationMessage.subject", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getReminder().setMessage(null)), "reminder.message", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getReminder().setIntervalInHours(0)), "reminder.intervalInHours", "must be greater than or equal to 1"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.getReminder().setStartDateTime(null)), "reminder.startDateTime", "must not be null"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(null)), "signatories", "must not be empty"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setName(null))))), "signatories[].name", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setPartyId(null))))), "signatories[].partyId", "not a valid UUID"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setEmail(null))))), "signatories[].email", "must not be blank"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setEmail("not-a-valid-email"))))), "signatories[].email", "must be a well-formed email address"),
+			Arguments.of("not valid", createStartSigningRequest(), "createSigning.municipalityId", "not a valid municipality ID"));
+	}
+
+	@ParameterizedTest
+	@MethodSource("provideBadRequests")
+	void createSigning_BadRequest(final String municipalityId, final StartSigningRequest request, final String field, final String message) {
+
+		final var path = "/" + municipalityId + "/e-signing/signings";
+
+		final var response = webTestClient.post()
+			.uri(path)
+			.bodyValue(request)
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectHeader().contentType(APPLICATION_PROBLEM_JSON_VALUE)
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response).isNotNull().satisfies(r -> {
+			assertThat(r.getTitle()).isEqualTo("Constraint Violation");
+			assertThat(r.getStatus()).isEqualTo(BAD_REQUEST);
+			assertThat(r.getViolations()).extracting(Violation::field, Violation::message)
+				.containsExactlyInAnyOrder(tuple(field, message));
+		});
+
+		verifyNoInteractions(signingGatewayServiceMock);
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
@@ -1,0 +1,54 @@
+package se.sundsvall.esigning.api;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import se.sundsvall.esigning.Application;
+import se.sundsvall.esigning.api.model.StartSigningResponse;
+import se.sundsvall.esigning.service.SigningGatewayService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+import static se.sundsvall.esigning.TestUtil.createStartSigningResponse;
+
+@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@ActiveProfiles("junit")
+@AutoConfigureWebTestClient
+class SigningGatewayResourceTest {
+
+	@MockitoBean
+	private SigningGatewayService signingGatewayServiceMock;
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Test
+	void createSigning() {
+		final var municipalityId = "2281";
+		final var request = createStartSigningRequest();
+		final var response = createStartSigningResponse();
+
+		when(signingGatewayServiceMock.startSigning(municipalityId, request)).thenReturn(response);
+
+		final var responseBody = webTestClient.post()
+			.uri("/" + municipalityId + "/e-signing/signings")
+			.bodyValue(request)
+			.exchange()
+			.expectStatus().isCreated()
+			.expectBody(StartSigningResponse.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(responseBody).isEqualTo(response);
+		verify(signingGatewayServiceMock).startSigning(municipalityId, request);
+		verifyNoMoreInteractions(signingGatewayServiceMock);
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/api/model/StartSigningResponseTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/StartSigningResponseTest.java
@@ -1,0 +1,61 @@
+package se.sundsvall.esigning.api.model;
+
+import com.google.code.beanmatchers.BeanMatchers;
+import java.util.Map;
+import java.util.UUID;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+
+class StartSigningResponseTest {
+
+	@BeforeAll
+	static void setup() {
+		BeanMatchers.registerValueGenerator(() -> Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString()), Map.class);
+	}
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(StartSigningResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builderTest() {
+		final var providerCaseId = "1234567890";
+		final var status = "INITIERAT";
+		final var provider = "comfact";
+		final var signatoryUrls = Map.of("550e8400-e29b-41d4-a716-446655440000", "https://sign.example/abc");
+
+		final var bean = StartSigningResponse.builder()
+			.withProviderCaseId(providerCaseId)
+			.withStatus(status)
+			.withProvider(provider)
+			.withSignatoryUrls(signatoryUrls)
+			.build();
+
+		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
+		assertThat(bean.getProviderCaseId()).isEqualTo(providerCaseId);
+		assertThat(bean.getStatus()).isEqualTo(status);
+		assertThat(bean.getProvider()).isEqualTo(provider);
+		assertThat(bean.getSignatoryUrls()).isEqualTo(signatoryUrls);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(StartSigningResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new StartSigningResponse()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
+++ b/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
@@ -1,0 +1,53 @@
+package se.sundsvall.esigning.service;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.esigning.provider.SigningProvider;
+import se.sundsvall.esigning.provider.SigningProviderRegistry;
+import se.sundsvall.esigning.provider.model.SigningResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
+
+@ExtendWith(MockitoExtension.class)
+class SigningGatewayServiceTest {
+
+	@Mock
+	private SigningProviderRegistry mockRegistry;
+
+	@Mock
+	private SigningProvider mockProvider;
+
+	@InjectMocks
+	private SigningGatewayService service;
+
+	@Test
+	void startSigning() {
+		final var municipalityId = "2281";
+		final var request = createStartSigningRequest();
+		final var signatoryUrls = Map.of("party", "url");
+		when(mockRegistry.resolve(municipalityId)).thenReturn(mockProvider);
+		when(mockProvider.startSigning(municipalityId, request)).thenReturn(new SigningResult("case-1", INITIERAT, signatoryUrls));
+		when(mockProvider.getId()).thenReturn("comfact");
+
+		final var response = service.startSigning(municipalityId, request);
+
+		assertThat(response.getProviderCaseId()).isEqualTo("case-1");
+		assertThat(response.getStatus()).isEqualTo("INITIERAT");
+		assertThat(response.getProvider()).isEqualTo("comfact");
+		assertThat(response.getSignatoryUrls()).isEqualTo(signatoryUrls);
+
+		verify(mockRegistry).resolve(municipalityId);
+		verify(mockProvider).startSigning(municipalityId, request);
+		verify(mockProvider).getId();
+		verifyNoMoreInteractions(mockRegistry, mockProvider);
+	}
+}


### PR DESCRIPTION
**Stacked PR 3/3** — builds on #47.

Exposes the synchronous create endpoint (Story: frontend create signing case).

- `POST /{municipalityId}/e-signing/signings` (`SigningGatewayResource` → `SigningGatewayService`): resolves the configured provider, synchronously starts the signing process, returns `{providerCaseId, status(normalized), provider, signatoryUrls}` (201). On provider failure nothing is started and the error propagates.
- `StartSigningResponse` model + regenerated `openapi.yml`
- Resource happy/failure, service and model tests

The old `POST /start` → pw-e-signing flow is left intact (removed in a later slice). `mvn verify` green.

Next (separate slices): inbound webhook/callback → pps, status normalization for events, removal of the old flow, and the coordinated comfact-facade + postportalservice work.