### PR TITLE
Add signing status endpoint with Comfact status normalization

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
+++ b/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.dept44.problem.violations.ConstraintViolationProblem;
+import se.sundsvall.esigning.api.model.SigningInstanceResponse;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
 import se.sundsvall.esigning.api.model.StartSigningResponse;
 import se.sundsvall.esigning.service.SigningGatewayService;
@@ -25,13 +27,13 @@ import se.sundsvall.esigning.service.SigningGatewayService;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.ok;
 import static org.springframework.http.ResponseEntity.status;
 
 @RestController
 @Validated
 @RequestMapping("/{municipalityId}/e-signing")
 @ApiResponses(value = {
-	@ApiResponse(responseCode = "201", description = "Created", content = @Content(mediaType = APPLICATION_JSON_VALUE), useReturnTypeSchema = true),
 	@ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(oneOf = {
 		Problem.class, ConstraintViolationProblem.class
 	}))),
@@ -47,12 +49,25 @@ class SigningGatewayResource {
 		this.signingGatewayService = signingGatewayService;
 	}
 
-	@Operation(summary = "Create a signing request via the configured signing provider")
+	@Operation(summary = "Create a signing request via the configured signing provider", responses = {
+		@ApiResponse(responseCode = "201", description = "Created", useReturnTypeSchema = true)
+	})
 	@PostMapping(value = "/signings", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	ResponseEntity<StartSigningResponse> createSigning(
 		@PathVariable @Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId final String municipalityId,
 		@Valid @RequestBody final StartSigningRequest request) {
 		return status(CREATED).body(signingGatewayService.startSigning(municipalityId, request));
+	}
+
+	@Operation(summary = "Get the current status of a signing case", responses = {
+		@ApiResponse(responseCode = "200", description = "OK", useReturnTypeSchema = true),
+		@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+	})
+	@GetMapping(value = "/signings/{providerCaseId}", produces = APPLICATION_JSON_VALUE)
+	ResponseEntity<SigningInstanceResponse> getSigningInstance(
+		@PathVariable @Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId final String municipalityId,
+		@PathVariable @Parameter(name = "providerCaseId", description = "The signing provider's case id", example = "1234567890") final String providerCaseId) {
+		return ok(signingGatewayService.getSigningInstance(municipalityId, providerCaseId));
 	}
 
 }

--- a/src/main/java/se/sundsvall/esigning/api/model/SigningInstanceResponse.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/SigningInstanceResponse.java
@@ -1,0 +1,40 @@
+package se.sundsvall.esigning.api.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.OffsetDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder(setterPrefix = "with")
+@Schema(description = "Signing instance response model")
+public class SigningInstanceResponse {
+
+	@Schema(description = "The signing provider's case id", examples = "1234567890")
+	private String providerCaseId;
+
+	@Schema(description = "The normalized status of the signing case", examples = "INVANTAR_SIGNERING", allowableValues = {
+		"INITIERAT", "INVANTAR_SIGNERING", "SIGNERAT", "UTGANGET", "FEL"
+	})
+	private String status;
+
+	@Schema(description = "The id of the signing provider that handled the request", examples = "comfact")
+	private String provider;
+
+	@Schema(description = "When the signing case expires", examples = "2026-12-31T23:59:59Z")
+	private OffsetDateTime expires;
+
+	@Schema(description = "The signed document, present only when status is SIGNERAT", implementation = SigningDocument.class)
+	private SigningDocument signedDocument;
+
+}

--- a/src/main/java/se/sundsvall/esigning/api/model/SigningInstanceResponse.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/SigningInstanceResponse.java
@@ -4,16 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
-@ToString
-@EqualsAndHashCode
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(setterPrefix = "with")

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
@@ -1,10 +1,12 @@
 package se.sundsvall.esigning.integration.comfactfacade;
 
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,4 +25,8 @@ public interface ComfactFacadeClient {
 	@Retry(name = CLIENT_ID)
 	@PostMapping(path = "/{municipalityId}/signings", consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
 	CreateSigningResponse createSigningRequest(@PathVariable("municipalityId") String municipalityId, @RequestBody SigningRequest request);
+
+	@Retry(name = CLIENT_ID)
+	@GetMapping(path = "/{municipalityId}/signings/{signingId}", produces = APPLICATION_JSON_VALUE)
+	SigningInstance getSigningInstance(@PathVariable("municipalityId") String municipalityId, @PathVariable("signingId") String signingId);
 }

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import se.sundsvall.dept44.problem.ThrowableProblem;
 
+import static se.sundsvall.dept44.util.LogUtils.sanitizeForLogging;
+
 @Component
 public class ComfactFacadeIntegration {
 
@@ -36,7 +38,8 @@ public class ComfactFacadeIntegration {
 			return comfactFacadeClient.getSigningInstance(municipalityId, signingId);
 		} catch (final ThrowableProblem e) {
 			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
-			LOGGER.error(COULD_NOT_GET_SIGNING.formatted(signingId, e.getMessage()));
+			// signingId is a user-provided path variable - sanitize it to avoid log injection.
+			LOGGER.error(COULD_NOT_GET_SIGNING.formatted(sanitizeForLogging(signingId), e.getMessage()));
 			throw e;
 		}
 	}

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning.integration.comfactfacade;
 
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +12,7 @@ import se.sundsvall.dept44.problem.ThrowableProblem;
 public class ComfactFacadeIntegration {
 
 	private static final String COULD_NOT_CREATE_SIGNING = "Could not create signing instance at Comfact facade. Error: %s";
+	private static final String COULD_NOT_GET_SIGNING = "Could not fetch signing instance %s at Comfact facade. Error: %s";
 	private static final Logger LOGGER = LoggerFactory.getLogger(ComfactFacadeIntegration.class);
 
 	private final ComfactFacadeClient comfactFacadeClient;
@@ -25,6 +27,16 @@ public class ComfactFacadeIntegration {
 		} catch (final ThrowableProblem e) {
 			// Preserve the provider's original problem (status + detail) so the caller gets a clear error.
 			LOGGER.error(COULD_NOT_CREATE_SIGNING.formatted(e.getMessage()));
+			throw e;
+		}
+	}
+
+	public SigningInstance getSigning(final String municipalityId, final String signingId) {
+		try {
+			return comfactFacadeClient.getSigningInstance(municipalityId, signingId);
+		} catch (final ThrowableProblem e) {
+			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
+			LOGGER.error(COULD_NOT_GET_SIGNING.formatted(signingId, e.getMessage()));
 			throw e;
 		}
 	}

--- a/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning.provider;
 
 import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.provider.model.SigningInstanceInfo;
 import se.sundsvall.esigning.provider.model.SigningResult;
 
 /**
@@ -23,4 +24,13 @@ public interface SigningProvider {
 	 * @return                the provider-neutral result including the provider's case id and the normalized status
 	 */
 	SigningResult startSigning(String municipalityId, StartSigningRequest request);
+
+	/**
+	 * Fetches the current snapshot of a signing case from the provider.
+	 *
+	 * @param  municipalityId the municipality the signing belongs to
+	 * @param  providerCaseId the provider's case id
+	 * @return                the provider-neutral snapshot including the normalized status and, once signed, the document
+	 */
+	SigningInstanceInfo getSigningInstance(String municipalityId, String providerCaseId);
 }

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
@@ -102,12 +102,19 @@ public final class ComfactSigningMapper {
 
 	public static SigningInstanceInfo toSigningInstanceInfo(final SigningInstance instance) {
 		final var statusCode = Optional.ofNullable(instance.getStatus()).map(Status::getCode).orElse(null);
+		final var status = toSigningStatus(statusCode);
+
+		// The signed document is only exposed once the case is signed (see SigningInstanceInfo / SigningInstanceResponse).
+		final var signedDocument = Optional.of(status)
+			.filter(SIGNERAT::equals)
+			.map(_ -> toSignedDocument(instance.getSignedDocument()))
+			.orElse(null);
 
 		return new SigningInstanceInfo(
 			instance.getSigningId(),
-			toSigningStatus(statusCode),
+			status,
 			instance.getExpires(),
-			toSignedDocument(instance.getSignedDocument()));
+			signedDocument);
 	}
 
 	static SigningDocument toSignedDocument(final Document document) {

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
@@ -6,17 +6,28 @@ import generated.se.sundsvall.comfactfacade.NotificationMessage;
 import generated.se.sundsvall.comfactfacade.Party;
 import generated.se.sundsvall.comfactfacade.Reminder;
 import generated.se.sundsvall.comfactfacade.Signatory;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
+import generated.se.sundsvall.comfactfacade.Status;
 import java.util.Base64;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import se.sundsvall.esigning.api.model.Initiator;
 import se.sundsvall.esigning.api.model.Message;
 import se.sundsvall.esigning.api.model.SigningDocument;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
+import se.sundsvall.esigning.provider.model.SigningInstanceInfo;
+import se.sundsvall.esigning.provider.model.SigningStatus;
+
+import static se.sundsvall.esigning.provider.model.SigningStatus.FEL;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INVANTAR_SIGNERING;
+import static se.sundsvall.esigning.provider.model.SigningStatus.SIGNERAT;
+import static se.sundsvall.esigning.provider.model.SigningStatus.UTGANGET;
 
 /**
- * Maps the provider-neutral API request to Comfact facade's generated request model.
+ * Maps between the provider-neutral API/domain models and Comfact facade's generated models.
  */
 public final class ComfactSigningMapper {
 
@@ -87,5 +98,41 @@ public final class ComfactSigningMapper {
 				.startDateTime(r.getStartDateTime())
 				.message(toNotificationMessage(r.getMessage(), language)))
 			.orElse(null);
+	}
+
+	public static SigningInstanceInfo toSigningInstanceInfo(final SigningInstance instance) {
+		final var statusCode = Optional.ofNullable(instance.getStatus()).map(Status::getCode).orElse(null);
+
+		return new SigningInstanceInfo(
+			instance.getSigningId(),
+			toSigningStatus(statusCode),
+			instance.getExpires(),
+			toSignedDocument(instance.getSignedDocument()));
+	}
+
+	static SigningDocument toSignedDocument(final Document document) {
+		return Optional.ofNullable(document)
+			.map(d -> SigningDocument.builder()
+				.withName(d.getName())
+				.withFileName(d.getFileName())
+				.withMimeType(d.getMimeType())
+				.withContent(Optional.ofNullable(d.getContent()).map(Base64.getEncoder()::encodeToString).orElse(null))
+				.build())
+			.orElse(null);
+	}
+
+	/**
+	 * Normalizes a Comfact status code to the domain status vocabulary. Matching is case-insensitive.
+	 */
+	static SigningStatus toSigningStatus(final String comfactStatusCode) {
+		return switch (Optional.ofNullable(comfactStatusCode).map(code -> code.toLowerCase(Locale.ROOT)).orElse("")) {
+			case "created" -> INITIERAT;
+			case "active", "reactivated", "approved" -> INVANTAR_SIGNERING;
+			case "completed" -> SIGNERAT;
+			case "expired" -> UTGANGET;
+			case "withdrawn", "declined", "halted", "faulty" -> FEL;
+			// Unknown/unset: do not finalize the case - the authoritative terminal status arrives via a known code.
+			default -> INVANTAR_SIGNERING;
+		};
 	}
 }

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
@@ -5,10 +5,12 @@ import org.springframework.stereotype.Component;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
 import se.sundsvall.esigning.integration.comfactfacade.ComfactFacadeIntegration;
 import se.sundsvall.esigning.provider.SigningProvider;
+import se.sundsvall.esigning.provider.model.SigningInstanceInfo;
 import se.sundsvall.esigning.provider.model.SigningResult;
 
 import static java.util.Collections.emptyMap;
 import static se.sundsvall.esigning.provider.comfact.ComfactSigningMapper.toComfactSigningRequest;
+import static se.sundsvall.esigning.provider.comfact.ComfactSigningMapper.toSigningInstanceInfo;
 import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
 
 /**
@@ -38,5 +40,10 @@ public class ComfactSigningProvider implements SigningProvider {
 			response.getSigningId(),
 			INITIERAT,
 			Optional.ofNullable(response.getSignatoryUrls()).orElse(emptyMap()));
+	}
+
+	@Override
+	public SigningInstanceInfo getSigningInstance(final String municipalityId, final String providerCaseId) {
+		return toSigningInstanceInfo(comfactFacadeIntegration.getSigning(municipalityId, providerCaseId));
 	}
 }

--- a/src/main/java/se/sundsvall/esigning/provider/model/SigningInstanceInfo.java
+++ b/src/main/java/se/sundsvall/esigning/provider/model/SigningInstanceInfo.java
@@ -1,0 +1,15 @@
+package se.sundsvall.esigning.provider.model;
+
+import java.time.OffsetDateTime;
+import se.sundsvall.esigning.api.model.SigningDocument;
+
+/**
+ * Provider-neutral snapshot of a signing case.
+ *
+ * @param providerCaseId the signing provider's own case/instance id
+ * @param status         the normalized status of the signing case
+ * @param expires        when the signing case expires, if known
+ * @param signedDocument the signed document, present only once the case is signed
+ */
+public record SigningInstanceInfo(String providerCaseId, SigningStatus status, OffsetDateTime expires, SigningDocument signedDocument) {
+}

--- a/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
+++ b/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning.service;
 
 import org.springframework.stereotype.Service;
+import se.sundsvall.esigning.api.model.SigningInstanceResponse;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
 import se.sundsvall.esigning.api.model.StartSigningResponse;
 import se.sundsvall.esigning.provider.SigningProvider;
@@ -28,6 +29,19 @@ public class SigningGatewayService {
 			.withStatus(result.status().name())
 			.withProvider(provider.getId())
 			.withSignatoryUrls(result.signatoryUrls())
+			.build();
+	}
+
+	public SigningInstanceResponse getSigningInstance(final String municipalityId, final String providerCaseId) {
+		final var provider = signingProviderRegistry.resolve(municipalityId);
+		final var info = provider.getSigningInstance(municipalityId, providerCaseId);
+
+		return SigningInstanceResponse.builder()
+			.withProviderCaseId(info.providerCaseId())
+			.withStatus(info.status().name())
+			.withProvider(provider.getId())
+			.withExpires(info.expires())
+			.withSignedDocument(info.signedDocument())
 			.build();
 	}
 }

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:57283
+- url: http://localhost:53625
   description: Generated server url
 tags:
 - name: eSigning
@@ -87,6 +87,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StartSigningResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/e-signing/signings/{providerCaseId}:
+    get:
+      tags:
+      - eSigning
+      summary: Get the current status of a signing case
+      operationId: getSigningInstance
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: providerCaseId
+        in: path
+        description: The signing provider's case id
+        required: true
+        schema:
+          type: string
+        example: 1234567890
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SigningInstanceResponse"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "400":
           description: Bad Request
           content:
@@ -480,4 +534,38 @@ components:
           additionalProperties:
             type: string
           description: "Direct signing urls per party id, when supplied by the provider"
+    SigningInstanceResponse:
+      type: object
+      description: Signing instance response model
+      properties:
+        providerCaseId:
+          type: string
+          description: The signing provider's case id
+          examples:
+          - "1234567890"
+        status:
+          type: string
+          description: The normalized status of the signing case
+          enum:
+          - INITIERAT
+          - INVANTAR_SIGNERING
+          - SIGNERAT
+          - UTGANGET
+          - FEL
+          examples:
+          - INVANTAR_SIGNERING
+        provider:
+          type: string
+          description: The id of the signing provider that handled the request
+          examples:
+          - comfact
+        expires:
+          type: string
+          format: date-time
+          description: When the signing case expires
+          examples:
+          - 2026-12-31T23:59:59Z
+        signedDocument:
+          $ref: "#/components/schemas/SigningDocument"
+          description: "The signed document, present only when status is SIGNERAT"
   securitySchemes: {}

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:58664
+- url: http://localhost:60089
   description: Generated server url
 tags:
 - name: eSigning
@@ -87,6 +87,60 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/StartSigningResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+  /{municipalityId}/e-signing/signings/{providerCaseId}:
+    get:
+      tags:
+      - eSigning
+      summary: Get the current status of a signing case
+      operationId: getSigningInstance
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: providerCaseId
+        in: path
+        description: The signing provider's case id
+        required: true
+        schema:
+          type: string
+        example: 1234567890
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SigningInstanceResponse"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
         "400":
           description: Bad Request
           content:
@@ -474,4 +528,38 @@ components:
           additionalProperties:
             type: string
           description: "Direct signing urls per party id, when supplied by the provider"
+    SigningInstanceResponse:
+      type: object
+      description: Signing instance response model
+      properties:
+        providerCaseId:
+          type: string
+          description: The signing provider's case id
+          examples:
+          - "1234567890"
+        status:
+          type: string
+          description: The normalized status of the signing case
+          enum:
+          - INITIERAT
+          - INVANTAR_SIGNERING
+          - SIGNERAT
+          - UTGANGET
+          - FEL
+          examples:
+          - INVANTAR_SIGNERING
+        provider:
+          type: string
+          description: The id of the signing provider that handled the request
+          examples:
+          - comfact
+        expires:
+          type: string
+          format: date-time
+          description: When the signing case expires
+          examples:
+          - 2026-12-31T23:59:59Z
+        signedDocument:
+          $ref: "#/components/schemas/SigningDocument"
+          description: "The signed document, present only when status is SIGNERAT"
   securitySchemes: {}

--- a/src/test/java/se/sundsvall/esigning/TestUtil.java
+++ b/src/test/java/se/sundsvall/esigning/TestUtil.java
@@ -13,6 +13,7 @@ import se.sundsvall.esigning.api.model.Message;
 import se.sundsvall.esigning.api.model.Reminder;
 import se.sundsvall.esigning.api.model.Signatory;
 import se.sundsvall.esigning.api.model.SigningDocument;
+import se.sundsvall.esigning.api.model.SigningInstanceResponse;
 import se.sundsvall.esigning.api.model.SigningRequest;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
 import se.sundsvall.esigning.api.model.StartSigningResponse;
@@ -191,6 +192,24 @@ public final class TestUtil {
 
 	public static StartSigningResponse createStartSigningResponse() {
 		return createStartSigningResponse(null);
+	}
+
+	public static SigningInstanceResponse createSigningInstanceResponse(final Consumer<SigningInstanceResponse> modifier) {
+		final var bean = SigningInstanceResponse.builder()
+			.withProviderCaseId("1234567890")
+			.withStatus("SIGNERAT")
+			.withProvider("comfact")
+			.withExpires(OffsetDateTime.now().plusDays(30))
+			.withSignedDocument(createSigningDocument())
+			.build();
+
+		Optional.ofNullable(modifier).ifPresent(m -> m.accept(bean));
+
+		return bean;
+	}
+
+	public static SigningInstanceResponse createSigningInstanceResponse() {
+		return createSigningInstanceResponse(null);
 	}
 
 }

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import se.sundsvall.esigning.Application;
+import se.sundsvall.esigning.api.model.SigningInstanceResponse;
 import se.sundsvall.esigning.api.model.StartSigningResponse;
 import se.sundsvall.esigning.service.SigningGatewayService;
 
@@ -16,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static se.sundsvall.esigning.TestUtil.createSigningInstanceResponse;
 import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
 import static se.sundsvall.esigning.TestUtil.createStartSigningResponse;
 
@@ -49,6 +51,27 @@ class SigningGatewayResourceTest {
 
 		assertThat(responseBody).isEqualTo(response);
 		verify(signingGatewayServiceMock).startSigning(municipalityId, request);
+		verifyNoMoreInteractions(signingGatewayServiceMock);
+	}
+
+	@Test
+	void getSigningInstance() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "1234567890";
+		final var response = createSigningInstanceResponse();
+
+		when(signingGatewayServiceMock.getSigningInstance(municipalityId, providerCaseId)).thenReturn(response);
+
+		final var responseBody = webTestClient.get()
+			.uri("/" + municipalityId + "/e-signing/signings/" + providerCaseId)
+			.exchange()
+			.expectStatus().isOk()
+			.expectBody(SigningInstanceResponse.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(responseBody).isEqualTo(response);
+		verify(signingGatewayServiceMock).getSigningInstance(municipalityId, providerCaseId);
 		verifyNoMoreInteractions(signingGatewayServiceMock);
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/api/model/SigningInstanceResponseTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/SigningInstanceResponseTest.java
@@ -1,0 +1,65 @@
+package se.sundsvall.esigning.api.model;
+
+import com.google.code.beanmatchers.BeanMatchers;
+import java.time.OffsetDateTime;
+import java.util.Random;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanConstructor;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanEquals;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanHashCode;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidBeanToString;
+import static com.google.code.beanmatchers.BeanMatchers.hasValidGettersAndSetters;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.allOf;
+import static se.sundsvall.esigning.TestUtil.createSigningDocument;
+
+class SigningInstanceResponseTest {
+
+	@BeforeAll
+	static void setup() {
+		BeanMatchers.registerValueGenerator(() -> OffsetDateTime.now().plusDays(new Random().nextInt()), OffsetDateTime.class);
+	}
+
+	@Test
+	void testBean() {
+		MatcherAssert.assertThat(SigningInstanceResponse.class, allOf(
+			hasValidBeanConstructor(),
+			hasValidGettersAndSetters(),
+			hasValidBeanHashCode(),
+			hasValidBeanEquals(),
+			hasValidBeanToString()));
+	}
+
+	@Test
+	void builderTest() {
+		final var providerCaseId = "1234567890";
+		final var status = "SIGNERAT";
+		final var provider = "comfact";
+		final var expires = OffsetDateTime.now().plusDays(30);
+		final var signedDocument = createSigningDocument();
+
+		final var bean = SigningInstanceResponse.builder()
+			.withProviderCaseId(providerCaseId)
+			.withStatus(status)
+			.withProvider(provider)
+			.withExpires(expires)
+			.withSignedDocument(signedDocument)
+			.build();
+
+		assertThat(bean).isNotNull().hasNoNullFieldsOrProperties();
+		assertThat(bean.getProviderCaseId()).isEqualTo(providerCaseId);
+		assertThat(bean.getStatus()).isEqualTo(status);
+		assertThat(bean.getProvider()).isEqualTo(provider);
+		assertThat(bean.getExpires()).isEqualTo(expires);
+		assertThat(bean.getSignedDocument()).isEqualTo(signedDocument);
+	}
+
+	@Test
+	void testNoDirtOnCreatedBean() {
+		assertThat(SigningInstanceResponse.builder().build()).hasAllNullFieldsOrProperties();
+		assertThat(new SigningInstanceResponse()).hasAllNullFieldsOrProperties();
+	}
+}

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning.integration.comfactfacade;
 
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,6 +18,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @ExtendWith(MockitoExtension.class)
 class ComfactFacadeIntegrationTest {
@@ -53,6 +55,35 @@ class ComfactFacadeIntegrationTest {
 			.hasFieldOrPropertyWithValue("status", BAD_REQUEST);
 
 		verify(mockClient).createSigningRequest(municipalityId, request);
+		verifyNoMoreInteractions(mockClient);
+	}
+
+	@Test
+	void getSigning() {
+		final var municipalityId = "2281";
+		final var signingId = "comfact-123";
+		final var instance = new SigningInstance().signingId(signingId);
+		when(mockClient.getSigningInstance(municipalityId, signingId)).thenReturn(instance);
+
+		final var result = integration.getSigning(municipalityId, signingId);
+
+		assertThat(result).isEqualTo(instance);
+		verify(mockClient).getSigningInstance(municipalityId, signingId);
+		verifyNoMoreInteractions(mockClient);
+	}
+
+	@Test
+	void getSigning_whenThrowsPropagatesProblem() {
+		final var municipalityId = "2281";
+		final var signingId = "comfact-123";
+		when(mockClient.getSigningInstance(municipalityId, signingId)).thenThrow(Problem.valueOf(NOT_FOUND, "No such signing instance"));
+
+		assertThatThrownBy(() -> integration.getSigning(municipalityId, signingId))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Not Found: No such signing instance")
+			.hasFieldOrPropertyWithValue("status", NOT_FOUND);
+
+		verify(mockClient).getSigningInstance(municipalityId, signingId);
 		verifyNoMoreInteractions(mockClient);
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.esigning.api.model.StartSigningRequest;
 import se.sundsvall.esigning.provider.configuration.ProviderProperties;
+import se.sundsvall.esigning.provider.model.SigningInstanceInfo;
 import se.sundsvall.esigning.provider.model.SigningResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -69,6 +70,11 @@ class SigningProviderRegistryTest {
 
 		@Override
 		public SigningResult startSigning(final String municipalityId, final StartSigningRequest request) {
+			return null;
+		}
+
+		@Override
+		public SigningInstanceInfo getSigningInstance(final String municipalityId, final String providerCaseId) {
 			return null;
 		}
 	}

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
@@ -1,10 +1,26 @@
 package se.sundsvall.esigning.provider.comfact;
 
+import generated.se.sundsvall.comfactfacade.Document;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
+import generated.se.sundsvall.comfactfacade.Status;
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import se.sundsvall.esigning.provider.model.SigningStatus;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
+import static se.sundsvall.esigning.provider.model.SigningStatus.FEL;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
+import static se.sundsvall.esigning.provider.model.SigningStatus.INVANTAR_SIGNERING;
+import static se.sundsvall.esigning.provider.model.SigningStatus.SIGNERAT;
+import static se.sundsvall.esigning.provider.model.SigningStatus.UTGANGET;
 
 class ComfactSigningMapperTest {
 
@@ -60,5 +76,66 @@ class ComfactSigningMapperTest {
 		assertThat(result.getLanguage()).isEqualTo(ComfactSigningMapper.DEFAULT_LANGUAGE);
 		assertThat(result.getNotificationMessage().getLanguage()).isEqualTo(ComfactSigningMapper.DEFAULT_LANGUAGE);
 		assertThat(result.getReminder()).isNull();
+	}
+
+	private static Stream<Arguments> statusMappings() {
+		return Stream.of(
+			Arguments.of("created", INITIERAT),
+			Arguments.of("active", INVANTAR_SIGNERING),
+			Arguments.of("reactivated", INVANTAR_SIGNERING),
+			Arguments.of("approved", INVANTAR_SIGNERING),
+			Arguments.of("Completed", SIGNERAT),
+			Arguments.of("expired", UTGANGET),
+			Arguments.of("withdrawn", FEL),
+			Arguments.of("declined", FEL),
+			Arguments.of("halted", FEL),
+			Arguments.of("faulty", FEL));
+	}
+
+	@ParameterizedTest
+	@MethodSource("statusMappings")
+	void toSigningStatus(final String comfactCode, final SigningStatus expected) {
+		assertThat(ComfactSigningMapper.toSigningStatus(comfactCode)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(strings = {
+		"", "something-unexpected"
+	})
+	void toSigningStatus_unknownOrNullIsNotFinalized(final String comfactCode) {
+		assertThat(ComfactSigningMapper.toSigningStatus(comfactCode)).isEqualTo(INVANTAR_SIGNERING);
+	}
+
+	@Test
+	void toSigningInstanceInfo() {
+		final var expires = OffsetDateTime.now().plusDays(10);
+		final var instance = new SigningInstance()
+			.signingId("comfact-123")
+			.status(new Status().code("Completed"))
+			.expires(expires)
+			.signedDocument(new Document().name("Contract").fileName("signed.pdf").mimeType("application/pdf").content("test".getBytes(StandardCharsets.UTF_8)));
+
+		final var info = ComfactSigningMapper.toSigningInstanceInfo(instance);
+
+		assertThat(info.providerCaseId()).isEqualTo("comfact-123");
+		assertThat(info.status()).isEqualTo(SIGNERAT);
+		assertThat(info.expires()).isEqualTo(expires);
+		assertThat(info.signedDocument()).isNotNull();
+		assertThat(info.signedDocument().getName()).isEqualTo("Contract");
+		assertThat(info.signedDocument().getFileName()).isEqualTo("signed.pdf");
+		assertThat(info.signedDocument().getMimeType()).isEqualTo("application/pdf");
+		assertThat(info.signedDocument().getContent()).isEqualTo("dGVzdA==");
+	}
+
+	@Test
+	void toSigningInstanceInfo_noSignedDocumentAndUnknownStatus() {
+		final var instance = new SigningInstance().signingId("comfact-123");
+
+		final var info = ComfactSigningMapper.toSigningInstanceInfo(instance);
+
+		assertThat(info.providerCaseId()).isEqualTo("comfact-123");
+		assertThat(info.status()).isEqualTo(INVANTAR_SIGNERING);
+		assertThat(info.signedDocument()).isNull();
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
@@ -138,4 +138,17 @@ class ComfactSigningMapperTest {
 		assertThat(info.status()).isEqualTo(INVANTAR_SIGNERING);
 		assertThat(info.signedDocument()).isNull();
 	}
+
+	@Test
+	void toSigningInstanceInfo_dropsSignedDocumentWhenNotSigned() {
+		final var instance = new SigningInstance()
+			.signingId("comfact-123")
+			.status(new Status().code("Active"))
+			.signedDocument(new Document().fileName("signed.pdf").mimeType("application/pdf").content("test".getBytes(StandardCharsets.UTF_8)));
+
+		final var info = ComfactSigningMapper.toSigningInstanceInfo(instance);
+
+		assertThat(info.status()).isEqualTo(INVANTAR_SIGNERING);
+		assertThat(info.signedDocument()).isNull();
+	}
 }

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
@@ -1,7 +1,12 @@
 package se.sundsvall.esigning.provider.comfact;
 
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
+import generated.se.sundsvall.comfactfacade.Document;
+import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
+import generated.se.sundsvall.comfactfacade.Status;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,5 +73,29 @@ class ComfactSigningProviderTest {
 		final var result = provider.startSigning(municipalityId, request);
 
 		assertThat(result.signatoryUrls()).isEmpty();
+	}
+
+	@Test
+	void getSigningInstance() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "comfact-123";
+		final var expires = OffsetDateTime.now().plusDays(10);
+		when(mockIntegration.getSigning(municipalityId, providerCaseId))
+			.thenReturn(new SigningInstance()
+				.signingId(providerCaseId)
+				.status(new Status().code("Completed"))
+				.expires(expires)
+				.signedDocument(new Document().fileName("signed.pdf").mimeType("application/pdf").content("test".getBytes(StandardCharsets.UTF_8))));
+
+		final var info = provider.getSigningInstance(municipalityId, providerCaseId);
+
+		assertThat(info.providerCaseId()).isEqualTo(providerCaseId);
+		assertThat(info.status()).isEqualTo(SigningStatus.SIGNERAT);
+		assertThat(info.expires()).isEqualTo(expires);
+		assertThat(info.signedDocument().getFileName()).isEqualTo("signed.pdf");
+		assertThat(info.signedDocument().getContent()).isEqualTo("dGVzdA==");
+
+		verify(mockIntegration).getSigning(municipalityId, providerCaseId);
+		verifyNoMoreInteractions(mockIntegration);
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
+++ b/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
@@ -1,5 +1,6 @@
 package se.sundsvall.esigning.service;
 
+import java.time.OffsetDateTime;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -8,14 +9,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import se.sundsvall.esigning.provider.SigningProvider;
 import se.sundsvall.esigning.provider.SigningProviderRegistry;
+import se.sundsvall.esigning.provider.model.SigningInstanceInfo;
 import se.sundsvall.esigning.provider.model.SigningResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static se.sundsvall.esigning.TestUtil.createSigningDocument;
 import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
 import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
+import static se.sundsvall.esigning.provider.model.SigningStatus.SIGNERAT;
 
 @ExtendWith(MockitoExtension.class)
 class SigningGatewayServiceTest {
@@ -47,6 +51,30 @@ class SigningGatewayServiceTest {
 
 		verify(mockRegistry).resolve(municipalityId);
 		verify(mockProvider).startSigning(municipalityId, request);
+		verify(mockProvider).getId();
+		verifyNoMoreInteractions(mockRegistry, mockProvider);
+	}
+
+	@Test
+	void getSigningInstance() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "case-1";
+		final var expires = OffsetDateTime.now().plusDays(10);
+		final var signedDocument = createSigningDocument();
+		when(mockRegistry.resolve(municipalityId)).thenReturn(mockProvider);
+		when(mockProvider.getSigningInstance(municipalityId, providerCaseId)).thenReturn(new SigningInstanceInfo(providerCaseId, SIGNERAT, expires, signedDocument));
+		when(mockProvider.getId()).thenReturn("comfact");
+
+		final var response = service.getSigningInstance(municipalityId, providerCaseId);
+
+		assertThat(response.getProviderCaseId()).isEqualTo(providerCaseId);
+		assertThat(response.getStatus()).isEqualTo("SIGNERAT");
+		assertThat(response.getProvider()).isEqualTo("comfact");
+		assertThat(response.getExpires()).isEqualTo(expires);
+		assertThat(response.getSignedDocument()).isEqualTo(signedDocument);
+
+		verify(mockRegistry).resolve(municipalityId);
+		verify(mockProvider).getSigningInstance(municipalityId, providerCaseId);
 		verify(mockProvider).getId();
 		verifyNoMoreInteractions(mockRegistry, mockProvider);
 	}


### PR DESCRIPTION
**Stacked PR 4** — builds on #48.

Adds the status/passthrough endpoint (Story: avsändare — see current status) and the Comfact→domain status normalization the earlier PRs deferred.

- `GET /{municipalityId}/e-signing/signings/{providerCaseId}` → `{providerCaseId, status(normalized), provider, expires, signedDocument?}`; the signed PDF is returned inline once the case is `SIGNERAT`.
- `ComfactSigningMapper.toSigningStatus`: Comfact status codes → `INITIERAT / INVANTAR_SIGNERING / SIGNERAT / UTGANGET / FEL` (case-insensitive; `withdrawn`/`declined`/`halted`/`faulty` → FEL; unknown/unset stays `INVANTAR_SIGNERING` so a case is never wrongly finalized).
- Extends the `SigningProvider` SPI + comfact-facade client/integration with a get-signing-instance operation; `SigningInstanceResponse` model; OpenAPI regenerated.

`mvn verify` green (149 tests, merged coverage 100%/100%).

Next: inbound webhook/callback → pps; removal of the old `/start` flow.