### PR TITLE
Set customerReference on create for event correlation

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
@@ -32,6 +32,11 @@ public class StartSigningRequest {
 	@Schema(description = "The language used for the signing instance. Swedish will be used if no language is provided", examples = "sv-SE", requiredMode = NOT_REQUIRED)
 	private String language;
 
+	@Schema(description = "The consumer's own reference for the case (e.g. Postportalen's MessageId). It is passed to the provider and echoed back verbatim in every event callback, so the consumer can correlate the case.",
+		examples = "550e8400-e29b-41d4-a716-446655440000",
+		requiredMode = NOT_REQUIRED)
+	private String customerReference;
+
 	@Future
 	@DateTimeFormat(iso = DATE_TIME)
 	@Schema(description = "Optional date and time when the signing request expires", examples = "2026-12-31T23:59:59Z", requiredMode = NOT_REQUIRED)

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
@@ -41,6 +41,7 @@ public final class ComfactSigningMapper {
 
 		return new SigningRequest()
 			.language(language)
+			.customerReference(request.getCustomerReference())
 			.expires(request.getExpires())
 			.document(toDocument(request.getDocument()))
 			.initiator(toInitiator(request.getInitiator()))

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:60089
+- url: http://localhost:50762
   description: Generated server url
 tags:
 - name: eSigning
@@ -388,10 +388,10 @@ components:
             $ref: "#/components/schemas/Violation"
         title:
           type: string
-        causeAsProblem:
-          $ref: "#/components/schemas/ThrowableProblem"
         detail:
           type: string
+        causeAsProblem:
+          $ref: "#/components/schemas/ThrowableProblem"
         instance:
           type: string
           format: uri
@@ -469,6 +469,13 @@ components:
             used if no language is provided
           examples:
           - sv-SE
+        customerReference:
+          type: string
+          description: "The consumer's own reference for the case (e.g. Postportalen's\
+            \ MessageId). It is passed to the provider and echoed back verbatim in\
+            \ every event callback, so the consumer can correlate the case."
+          examples:
+          - 550e8400-e29b-41d4-a716-446655440000
         expires:
           type: string
           format: date-time

--- a/src/test/java/se/sundsvall/esigning/TestUtil.java
+++ b/src/test/java/se/sundsvall/esigning/TestUtil.java
@@ -160,6 +160,7 @@ public final class TestUtil {
 		final var bean = StartSigningRequest.builder()
 			.withExpires(OffsetDateTime.now().plusDays(1))
 			.withLanguage("sv-SE")
+			.withCustomerReference("550e8400-e29b-41d4-a716-446655440000")
 			.withNotificationMessage(createMessage())
 			.withInitiator(createInitiator())
 			.withReminder(createReminder())

--- a/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
@@ -42,6 +42,7 @@ class StartSigningRequestTest {
 	void builderTest() {
 		final var expires = OffsetDateTime.now();
 		final var language = "sv-SE";
+		final var customerReference = "550e8400-e29b-41d4-a716-446655440000";
 		final var reminder = createReminder();
 		final var signatories = Set.of(createSignatory());
 		final var message = createMessage();
@@ -52,6 +53,7 @@ class StartSigningRequestTest {
 			.withExpires(expires)
 			.withDocument(document)
 			.withLanguage(language)
+			.withCustomerReference(customerReference)
 			.withReminder(reminder)
 			.withSignatories(signatories)
 			.withNotificationMessage(message)
@@ -61,6 +63,7 @@ class StartSigningRequestTest {
 		assertThat(bean).satisfies(b -> {
 			assertThat(b.getExpires()).isEqualTo(expires);
 			assertThat(b.getLanguage()).isEqualTo(language);
+			assertThat(b.getCustomerReference()).isEqualTo(customerReference);
 			assertThat(b.getReminder()).isEqualTo(reminder);
 			assertThat(b.getSignatories()).isEqualTo(signatories);
 			assertThat(b.getNotificationMessage()).isEqualTo(message);

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
@@ -32,6 +32,7 @@ class ComfactSigningMapperTest {
 		final var result = ComfactSigningMapper.toComfactSigningRequest(request);
 
 		assertThat(result.getLanguage()).isEqualTo("sv-SE");
+		assertThat(result.getCustomerReference()).isEqualTo(request.getCustomerReference());
 		assertThat(result.getExpires()).isEqualTo(request.getExpires());
 
 		assertThat(result.getNotificationMessage()).isNotNull();


### PR DESCRIPTION
Companion to #50. Adds an optional `customerReference` to `StartSigningRequest` (Postportalen's MessageId) and maps it into comfact-facade's `SigningRequest.customerReference`.

Comfact echoes it back verbatim in every event callback, so pps correlates the Message by it (the `SigningEvent` produced by #50's webhook already carries `customerReference`; this sets it at create). Optional at the API layer so non-pps callers aren't forced to supply it.

`mvn verify` green (merged coverage 100%/100%); OpenAPI regenerated.