### PR TITLE
Send the message id as a path variable on the Postportalservice callback

### DIFF
--- a/src/integration-test/resources/ComfactWebhookResourceIT/__files/test01_relayCompletedEvent/mappings/postportalservice-events.json
+++ b/src/integration-test/resources/ComfactWebhookResourceIT/__files/test01_relayCompletedEvent/mappings/postportalservice-events.json
@@ -9,7 +9,7 @@
 			}
 		},
 		"method": "POST",
-		"url": "/postportalservice/2281/e-signing/events",
+		"url": "/postportalservice/2281/e-signing/events/550e8400-e29b-41d4-a716-446655440000",
 		"bodyPatterns": [
 			{
 				"equalToJson": {

--- a/src/main/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceClient.java
+++ b/src/main/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceClient.java
@@ -19,6 +19,6 @@ import static se.sundsvall.esigning.integration.postportalservice.configuration.
 public interface PostportalserviceClient {
 
 	@Retry(name = CLIENT_ID)
-	@PostMapping(path = "/{municipalityId}/e-signing/events", consumes = APPLICATION_JSON_VALUE)
-	void sendEvent(@PathVariable String municipalityId, @RequestBody SigningEvent signingEvent);
+	@PostMapping(path = "/{municipalityId}/e-signing/events/{messageId}", consumes = APPLICATION_JSON_VALUE)
+	void sendEvent(@PathVariable String municipalityId, @PathVariable String messageId, @RequestBody SigningEvent signingEvent);
 }

--- a/src/main/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceIntegration.java
@@ -19,7 +19,8 @@ public class PostportalserviceIntegration {
 
 	public void sendEvent(final String municipalityId, final SigningEvent signingEvent) {
 		try {
-			postportalserviceClient.sendEvent(municipalityId, signingEvent);
+			// customerReference is the Postportalen message id; it identifies the signing case as a path variable.
+			postportalserviceClient.sendEvent(municipalityId, signingEvent.customerReference(), signingEvent);
 		} catch (final ThrowableProblem e) {
 			// Rethrow with the case id as context so the whole webhook chain fails and the provider retries the
 			// delivery later. The propagated problem is logged upstream by the framework; providerCaseId comes from an

--- a/src/test/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceIntegrationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/postportalservice/PostportalserviceIntegrationTest.java
@@ -31,7 +31,7 @@ class PostportalserviceIntegrationTest {
 
 		assertThatNoException().isThrownBy(() -> integration.sendEvent(municipalityId, event));
 
-		verify(mockClient).sendEvent(municipalityId, event);
+		verify(mockClient).sendEvent(municipalityId, event.customerReference(), event);
 		verifyNoMoreInteractions(mockClient);
 	}
 
@@ -39,7 +39,7 @@ class PostportalserviceIntegrationTest {
 	void sendEvent_whenThrowsPropagatesProblem() {
 		final var municipalityId = "2281";
 		final var event = createSigningEvent();
-		doThrow(Problem.valueOf(BAD_GATEWAY, "Postportalservice unavailable")).when(mockClient).sendEvent(municipalityId, event);
+		doThrow(Problem.valueOf(BAD_GATEWAY, "Postportalservice unavailable")).when(mockClient).sendEvent(municipalityId, event.customerReference(), event);
 
 		assertThatThrownBy(() -> integration.sendEvent(municipalityId, event))
 			.isInstanceOf(Problem.class)
@@ -47,7 +47,7 @@ class PostportalserviceIntegrationTest {
 			.hasMessageContaining("Postportalservice unavailable")
 			.hasFieldOrPropertyWithValue("status", BAD_GATEWAY);
 
-		verify(mockClient).sendEvent(municipalityId, event);
+		verify(mockClient).sendEvent(municipalityId, event.customerReference(), event);
 		verifyNoMoreInteractions(mockClient);
 	}
 }


### PR DESCRIPTION
## What

Follow-up to #50 (merged). Per review with André/Linus, the callback to Postportalservice now correlates on **Postportalen's own message id** instead of the provider case id in the body.

`PostportalserviceClient.sendEvent` now posts to `POST /{municipalityId}/e-signing/events/{messageId}`, passing the `SigningEvent`'s `customerReference` (which is the pps message id) as the path variable. On the pps side this lets it reach the signing case directly via `message.getSigning()` (JPA) without a provider-case-id lookup.

## Changes

- `PostportalserviceClient` — path `/events/{messageId}`, extra `@PathVariable messageId`.
- `PostportalserviceIntegration` — passes `signingEvent.customerReference()` as the message id.
- `ComfactWebhookResourceIT` WireMock stub + `PostportalserviceIntegrationTest` updated for the new path.

## Testing

`mvn verify` green — the AppTest confirms the relay hits `/postportalservice/2281/e-signing/events/{messageId}`.

## Paired with

api-service-postportalservice PR #100 (the pps callback receiver `POST /e-signing/events/{messageId}`).