### PR TITLE
HYDRAN-2582: Cancel-signing passthrough to the provider

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
+++ b/src/main/java/se/sundsvall/esigning/api/SigningGatewayResource.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +28,7 @@ import se.sundsvall.esigning.service.SigningGatewayService;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.noContent;
 import static org.springframework.http.ResponseEntity.ok;
 import static org.springframework.http.ResponseEntity.status;
 
@@ -68,6 +70,20 @@ class SigningGatewayResource {
 		@PathVariable @Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId final String municipalityId,
 		@PathVariable @Parameter(name = "providerCaseId", description = "The signing provider's case id", example = "1234567890") final String providerCaseId) {
 		return ok(signingGatewayService.getSigningInstance(municipalityId, providerCaseId));
+	}
+
+	@Operation(summary = "Cancel a signing case via the configured signing provider",
+		description = "Withdraws the signing case at the provider so it stops progressing. The final state is confirmed asynchronously through the provider callback.",
+		responses = {
+			@ApiResponse(responseCode = "204", description = "No Content"),
+			@ApiResponse(responseCode = "404", description = "Not Found", content = @Content(mediaType = APPLICATION_PROBLEM_JSON_VALUE, schema = @Schema(implementation = Problem.class)))
+		})
+	@DeleteMapping(value = "/signings/{providerCaseId}")
+	ResponseEntity<Void> cancelSigning(
+		@PathVariable @Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @ValidMunicipalityId final String municipalityId,
+		@PathVariable @Parameter(name = "providerCaseId", description = "The signing provider's case id", example = "1234567890") final String providerCaseId) {
+		signingGatewayService.cancelSigning(municipalityId, providerCaseId);
+		return noContent().build();
 	}
 
 }

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeClient.java
@@ -3,10 +3,12 @@ package se.sundsvall.esigning.integration.comfactfacade;
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
 import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
+import generated.se.sundsvall.comfactfacade.UpdateSigningRequest;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
 import io.github.resilience4j.retry.annotation.Retry;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,4 +31,8 @@ public interface ComfactFacadeClient {
 	@Retry(name = CLIENT_ID)
 	@GetMapping(path = "/{municipalityId}/signings/{signingId}", produces = APPLICATION_JSON_VALUE)
 	SigningInstance getSigningInstance(@PathVariable("municipalityId") String municipalityId, @PathVariable("signingId") String signingId);
+
+	@Retry(name = CLIENT_ID)
+	@PatchMapping(path = "/{municipalityId}/signings/{signingId}", consumes = APPLICATION_JSON_VALUE)
+	void updateSigningRequest(@PathVariable("municipalityId") String municipalityId, @PathVariable("signingId") String signingId, @RequestBody UpdateSigningRequest request);
 }

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
@@ -3,6 +3,7 @@ package se.sundsvall.esigning.integration.comfactfacade;
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
 import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
+import generated.se.sundsvall.comfactfacade.UpdateSigningRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -13,8 +14,12 @@ import static se.sundsvall.dept44.util.LogUtils.sanitizeForLogging;
 @Component
 public class ComfactFacadeIntegration {
 
+	// Comfact status a signing instance is patched to in order to cancel it (see api-comfact-facade UpdateSigningRequest).
+	private static final String STATUS_WITHDRAWN = "withdrawn";
+
 	private static final String COULD_NOT_CREATE_SIGNING = "Could not create signing instance at Comfact facade. Error: %s";
 	private static final String COULD_NOT_GET_SIGNING = "Could not fetch signing instance %s at Comfact facade. Error: %s";
+	private static final String COULD_NOT_WITHDRAW_SIGNING = "Could not withdraw signing instance %s at Comfact facade. Error: %s";
 	private static final Logger LOGGER = LoggerFactory.getLogger(ComfactFacadeIntegration.class);
 
 	private final ComfactFacadeClient comfactFacadeClient;
@@ -40,6 +45,17 @@ public class ComfactFacadeIntegration {
 			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
 			// signingId is a user-provided path variable - sanitize it to avoid log injection.
 			LOGGER.error(COULD_NOT_GET_SIGNING.formatted(sanitizeForLogging(signingId), e.getMessage()));
+			throw e;
+		}
+	}
+
+	public void withdrawSigning(final String municipalityId, final String signingId) {
+		try {
+			comfactFacadeClient.updateSigningRequest(municipalityId, signingId, new UpdateSigningRequest().status(STATUS_WITHDRAWN));
+		} catch (final ThrowableProblem e) {
+			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
+			// signingId is a user-provided path variable - sanitize it to avoid log injection.
+			LOGGER.error(COULD_NOT_WITHDRAW_SIGNING.formatted(sanitizeForLogging(signingId), e.getMessage()));
 			throw e;
 		}
 	}

--- a/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
+++ b/src/main/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegration.java
@@ -4,9 +4,8 @@ import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
 import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
 import generated.se.sundsvall.comfactfacade.UpdateSigningRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import se.sundsvall.dept44.problem.Problem;
 import se.sundsvall.dept44.problem.ThrowableProblem;
 
 import static se.sundsvall.dept44.util.LogUtils.sanitizeForLogging;
@@ -20,7 +19,6 @@ public class ComfactFacadeIntegration {
 	private static final String COULD_NOT_CREATE_SIGNING = "Could not create signing instance at Comfact facade. Error: %s";
 	private static final String COULD_NOT_GET_SIGNING = "Could not fetch signing instance %s at Comfact facade. Error: %s";
 	private static final String COULD_NOT_WITHDRAW_SIGNING = "Could not withdraw signing instance %s at Comfact facade. Error: %s";
-	private static final Logger LOGGER = LoggerFactory.getLogger(ComfactFacadeIntegration.class);
 
 	private final ComfactFacadeClient comfactFacadeClient;
 
@@ -32,9 +30,7 @@ public class ComfactFacadeIntegration {
 		try {
 			return comfactFacadeClient.createSigningRequest(municipalityId, request);
 		} catch (final ThrowableProblem e) {
-			// Preserve the provider's original problem (status + detail) so the caller gets a clear error.
-			LOGGER.error(COULD_NOT_CREATE_SIGNING.formatted(e.getMessage()));
-			throw e;
+			throw Problem.valueOf(e.getStatus(), COULD_NOT_CREATE_SIGNING.formatted(e.getDetail()));
 		}
 	}
 
@@ -42,10 +38,7 @@ public class ComfactFacadeIntegration {
 		try {
 			return comfactFacadeClient.getSigningInstance(municipalityId, signingId);
 		} catch (final ThrowableProblem e) {
-			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
-			// signingId is a user-provided path variable - sanitize it to avoid log injection.
-			LOGGER.error(COULD_NOT_GET_SIGNING.formatted(sanitizeForLogging(signingId), e.getMessage()));
-			throw e;
+			throw Problem.valueOf(e.getStatus(), COULD_NOT_GET_SIGNING.formatted(sanitizeForLogging(signingId), e.getDetail()));
 		}
 	}
 
@@ -53,10 +46,7 @@ public class ComfactFacadeIntegration {
 		try {
 			comfactFacadeClient.updateSigningRequest(municipalityId, signingId, new UpdateSigningRequest().status(STATUS_WITHDRAWN));
 		} catch (final ThrowableProblem e) {
-			// Preserve the provider's original problem (e.g. 404 for an unknown case) so the caller gets a clear error.
-			// signingId is a user-provided path variable - sanitize it to avoid log injection.
-			LOGGER.error(COULD_NOT_WITHDRAW_SIGNING.formatted(sanitizeForLogging(signingId), e.getMessage()));
-			throw e;
+			throw Problem.valueOf(e.getStatus(), COULD_NOT_WITHDRAW_SIGNING.formatted(sanitizeForLogging(signingId), e.getDetail()));
 		}
 	}
 }

--- a/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/SigningProvider.java
@@ -33,4 +33,12 @@ public interface SigningProvider {
 	 * @return                the provider-neutral snapshot including the normalized status and, once signed, the document
 	 */
 	SigningInstanceInfo getSigningInstance(String municipalityId, String providerCaseId);
+
+	/**
+	 * Cancels an in-progress signing case at the provider (the provider stops it from progressing any further).
+	 *
+	 * @param municipalityId the municipality the signing belongs to
+	 * @param providerCaseId the provider's case id
+	 */
+	void cancelSigning(String municipalityId, String providerCaseId);
 }

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProvider.java
@@ -46,4 +46,9 @@ public class ComfactSigningProvider implements SigningProvider {
 	public SigningInstanceInfo getSigningInstance(final String municipalityId, final String providerCaseId) {
 		return toSigningInstanceInfo(comfactFacadeIntegration.getSigning(municipalityId, providerCaseId));
 	}
+
+	@Override
+	public void cancelSigning(final String municipalityId, final String providerCaseId) {
+		comfactFacadeIntegration.withdrawSigning(municipalityId, providerCaseId);
+	}
 }

--- a/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
+++ b/src/main/java/se/sundsvall/esigning/service/SigningGatewayService.java
@@ -44,4 +44,9 @@ public class SigningGatewayService {
 			.withSignedDocument(info.signedDocument())
 			.build();
 	}
+
+	public void cancelSigning(final String municipalityId, final String providerCaseId) {
+		final var provider = signingProviderRegistry.resolve(municipalityId);
+		provider.cancelSigning(municipalityId, providerCaseId);
+	}
 }

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:60089
+- url: http://localhost:63765
   description: Generated server url
 tags:
 - name: eSigning
@@ -135,6 +135,57 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SigningInstanceResponse"
+        "404":
+          description: Not Found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "400":
+          description: Bad Request
+          content:
+            application/problem+json:
+              schema:
+                oneOf:
+                - $ref: "#/components/schemas/Problem"
+                - $ref: "#/components/schemas/ConstraintViolationProblem"
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+        "502":
+          description: Bad Gateway
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+    delete:
+      tags:
+      - eSigning
+      summary: Cancel a signing case via the configured signing provider
+      description: Withdraws the signing case at the provider so it stops progressing.
+        The final state is confirmed asynchronously through the provider callback.
+      operationId: cancelSigning
+      parameters:
+      - name: municipalityId
+        in: path
+        description: Municipality id
+        required: true
+        schema:
+          type: string
+        example: 2281
+      - name: providerCaseId
+        in: path
+        description: The signing provider's case id
+        required: true
+        schema:
+          type: string
+        example: 1234567890
+      responses:
+        "204":
+          description: No Content
         "404":
           description: Not Found
           content:

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
@@ -3,6 +3,7 @@ package se.sundsvall.esigning.api;
 import java.time.OffsetDateTime;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -88,6 +89,27 @@ class SigningGatewayResourceFailureTest {
 			assertThat(r.getStatus()).isEqualTo(BAD_REQUEST);
 			assertThat(r.getViolations()).extracting(Violation::field, Violation::message)
 				.containsExactlyInAnyOrder(tuple(field, message));
+		});
+
+		verifyNoInteractions(signingGatewayServiceMock);
+	}
+
+	@Test
+	void cancelSigning_invalidMunicipalityId() {
+		final var response = webTestClient.delete()
+			.uri("/not-valid/e-signing/signings/1234567890")
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectHeader().contentType(APPLICATION_PROBLEM_JSON_VALUE)
+			.expectBody(ConstraintViolationProblem.class)
+			.returnResult()
+			.getResponseBody();
+
+		assertThat(response).isNotNull().satisfies(r -> {
+			assertThat(r.getTitle()).isEqualTo("Constraint Violation");
+			assertThat(r.getStatus()).isEqualTo(BAD_REQUEST);
+			assertThat(r.getViolations()).extracting(Violation::field, Violation::message)
+				.containsExactlyInAnyOrder(tuple("cancelSigning.municipalityId", "not a valid municipality ID"));
 		});
 
 		verifyNoInteractions(signingGatewayServiceMock);

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceTest.java
@@ -74,4 +74,18 @@ class SigningGatewayResourceTest {
 		verify(signingGatewayServiceMock).getSigningInstance(municipalityId, providerCaseId);
 		verifyNoMoreInteractions(signingGatewayServiceMock);
 	}
+
+	@Test
+	void cancelSigning() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "1234567890";
+
+		webTestClient.delete()
+			.uri("/" + municipalityId + "/e-signing/signings/" + providerCaseId)
+			.exchange()
+			.expectStatus().isNoContent();
+
+		verify(signingGatewayServiceMock).cancelSigning(municipalityId, providerCaseId);
+		verifyNoMoreInteractions(signingGatewayServiceMock);
+	}
 }

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
@@ -55,7 +55,7 @@ class ComfactFacadeIntegrationTest {
 
 		assertThatThrownBy(() -> integration.createSigning(municipalityId, request))
 			.isInstanceOf(Problem.class)
-			.hasMessage("Bad Request: Bad partyId")
+			.hasMessage("Bad Request: Could not create signing instance at Comfact facade. Error: Bad partyId")
 			.hasFieldOrPropertyWithValue("status", BAD_REQUEST);
 
 		verify(mockClient).createSigningRequest(municipalityId, request);
@@ -84,7 +84,7 @@ class ComfactFacadeIntegrationTest {
 
 		assertThatThrownBy(() -> integration.getSigning(municipalityId, signingId))
 			.isInstanceOf(Problem.class)
-			.hasMessage("Not Found: No such signing instance")
+			.hasMessage("Not Found: Could not fetch signing instance comfact-123 at Comfact facade. Error: No such signing instance")
 			.hasFieldOrPropertyWithValue("status", NOT_FOUND);
 
 		verify(mockClient).getSigningInstance(municipalityId, signingId);
@@ -112,7 +112,7 @@ class ComfactFacadeIntegrationTest {
 
 		assertThatThrownBy(() -> integration.withdrawSigning(municipalityId, signingId))
 			.isInstanceOf(Problem.class)
-			.hasMessage("Not Found: No such signing instance")
+			.hasMessage("Not Found: Could not withdraw signing instance comfact-123 at Comfact facade. Error: No such signing instance")
 			.hasFieldOrPropertyWithValue("status", NOT_FOUND);
 
 		verify(mockClient).updateSigningRequest(eq(municipalityId), eq(signingId), any());

--- a/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
+++ b/src/test/java/se/sundsvall/esigning/integration/comfactfacade/ComfactFacadeIntegrationTest.java
@@ -3,8 +3,10 @@ package se.sundsvall.esigning.integration.comfactfacade;
 import generated.se.sundsvall.comfactfacade.CreateSigningResponse;
 import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.SigningRequest;
+import generated.se.sundsvall.comfactfacade.UpdateSigningRequest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -14,6 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -84,6 +88,34 @@ class ComfactFacadeIntegrationTest {
 			.hasFieldOrPropertyWithValue("status", NOT_FOUND);
 
 		verify(mockClient).getSigningInstance(municipalityId, signingId);
+		verifyNoMoreInteractions(mockClient);
+	}
+
+	@Test
+	void withdrawSigning() {
+		final var municipalityId = "2281";
+		final var signingId = "comfact-123";
+
+		integration.withdrawSigning(municipalityId, signingId);
+
+		final var captor = ArgumentCaptor.forClass(UpdateSigningRequest.class);
+		verify(mockClient).updateSigningRequest(eq(municipalityId), eq(signingId), captor.capture());
+		assertThat(captor.getValue().getStatus()).isEqualTo("withdrawn");
+		verifyNoMoreInteractions(mockClient);
+	}
+
+	@Test
+	void withdrawSigning_whenThrowsPropagatesProblem() {
+		final var municipalityId = "2281";
+		final var signingId = "comfact-123";
+		doThrow(Problem.valueOf(NOT_FOUND, "No such signing instance")).when(mockClient).updateSigningRequest(eq(municipalityId), eq(signingId), any());
+
+		assertThatThrownBy(() -> integration.withdrawSigning(municipalityId, signingId))
+			.isInstanceOf(Problem.class)
+			.hasMessage("Not Found: No such signing instance")
+			.hasFieldOrPropertyWithValue("status", NOT_FOUND);
+
+		verify(mockClient).updateSigningRequest(eq(municipalityId), eq(signingId), any());
 		verifyNoMoreInteractions(mockClient);
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/SigningProviderRegistryTest.java
@@ -77,5 +77,10 @@ class SigningProviderRegistryTest {
 		public SigningInstanceInfo getSigningInstance(final String municipalityId, final String providerCaseId) {
 			return null;
 		}
+
+		@Override
+		public void cancelSigning(final String municipalityId, final String providerCaseId) {
+			// no-op test stub
+		}
 	}
 }

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningProviderTest.java
@@ -98,4 +98,15 @@ class ComfactSigningProviderTest {
 		verify(mockIntegration).getSigning(municipalityId, providerCaseId);
 		verifyNoMoreInteractions(mockIntegration);
 	}
+
+	@Test
+	void cancelSigning() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "comfact-123";
+
+		provider.cancelSigning(municipalityId, providerCaseId);
+
+		verify(mockIntegration).withdrawSigning(municipalityId, providerCaseId);
+		verifyNoMoreInteractions(mockIntegration);
+	}
 }

--- a/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
+++ b/src/test/java/se/sundsvall/esigning/service/SigningGatewayServiceTest.java
@@ -78,4 +78,17 @@ class SigningGatewayServiceTest {
 		verify(mockProvider).getId();
 		verifyNoMoreInteractions(mockRegistry, mockProvider);
 	}
+
+	@Test
+	void cancelSigning() {
+		final var municipalityId = "2281";
+		final var providerCaseId = "case-1";
+		when(mockRegistry.resolve(municipalityId)).thenReturn(mockProvider);
+
+		service.cancelSigning(municipalityId, providerCaseId);
+
+		verify(mockRegistry).resolve(municipalityId);
+		verify(mockProvider).cancelSigning(municipalityId, providerCaseId);
+		verifyNoMoreInteractions(mockRegistry, mockProvider);
+	}
 }


### PR DESCRIPTION
Adds `DELETE /{municipalityId}/e-signing/signings/{providerCaseId}` to cancel a signing case via the configured provider.

- New `cancelSigning` on the `SigningProvider` SPI + `SigningGatewayService`.
- `ComfactSigningProvider` withdraws the case at Comfact by PATCHing its status to `withdrawn` through api-comfact-facade (`ComfactFacadeClient.updateSigningRequest` / `ComfactFacadeIntegration.withdrawSigning`).
- Returns 204; final state is confirmed asynchronously via the provider callback.
- Full unit coverage (SPI/provider/service/resource happy + resource bad-request, integration success/error); OpenAPI regenerated.

Consumed by the pps cancel endpoint (api-service-postportalservice HYDRAN-2582).