### PR TITLE
Support attachments alongside the primary signing document

### DIFF
--- a/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
+++ b/src/main/java/se/sundsvall/esigning/api/model/StartSigningRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -44,8 +45,11 @@ public class StartSigningRequest {
 
 	@Valid
 	@NotNull
-	@Schema(description = "The document to sign", implementation = SigningDocument.class, requiredMode = REQUIRED)
+	@Schema(description = "The primary document to sign", implementation = SigningDocument.class, requiredMode = REQUIRED)
 	private SigningDocument document;
+
+	@ArraySchema(schema = @Schema(implementation = SigningDocument.class), arraySchema = @Schema(description = "Optional additional documents (attachments) included in the signing alongside the primary document", requiredMode = NOT_REQUIRED))
+	private List<@Valid SigningDocument> attachments;
 
 	@Valid
 	@NotNull

--- a/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
+++ b/src/main/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapper.java
@@ -51,6 +51,7 @@ public final class ComfactSigningMapper {
 			.customerReference(request.getCustomerReference())
 			.expires(request.getExpires())
 			.document(toDocument(request.getDocument()))
+			.additionalDocuments(toAdditionalDocuments(request.getAttachments()))
 			.initiator(toInitiator(request.getInitiator()))
 			.notificationMessage(toNotificationMessage(request.getNotificationMessage(), language))
 			.reminder(toReminder(request.getReminder(), language))
@@ -63,6 +64,12 @@ public final class ComfactSigningMapper {
 			.fileName(document.getFileName())
 			.mimeType(document.getMimeType())
 			.content(Base64.getDecoder().decode(document.getContent()));
+	}
+
+	static List<Document> toAdditionalDocuments(final List<SigningDocument> attachments) {
+		return Optional.ofNullable(attachments).orElseGet(List::of).stream()
+			.map(ComfactSigningMapper::toDocument)
+			.toList();
 	}
 
 	static Party toInitiator(final Initiator initiator) {

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -7,7 +7,7 @@ info:
     url: https://opensource.org/licenses/MIT
   version: "2.0"
 servers:
-- url: http://localhost:50762
+- url: http://localhost:57681
   description: Generated server url
 tags:
 - name: eSigning
@@ -353,10 +353,10 @@ components:
             $ref: "#/components/schemas/Violation"
         title:
           type: string
-        detail:
-          type: string
         causeAsProblem:
           $ref: "#/components/schemas/ThrowableProblem"
+        detail:
+          type: string
         instance:
           type: string
           format: uri
@@ -562,68 +562,6 @@ components:
       - initiator
       - notificationMessage
       - signatories
-    Problem:
-      type: object
-      properties:
-        title:
-          type: string
-        detail:
-          type: string
-        instance:
-          type: string
-          format: uri
-        type:
-          type: string
-          format: uri
-        status:
-          type: integer
-          format: int32
-    ConstraintViolationProblem:
-      type: object
-      properties:
-        type:
-          type: string
-          format: uri
-        status:
-          type: integer
-          format: int32
-        violations:
-          type: array
-          items:
-            $ref: "#/components/schemas/Violation"
-        title:
-          type: string
-        detail:
-          type: string
-        causeAsProblem:
-          $ref: "#/components/schemas/ThrowableProblem"
-        instance:
-          type: string
-          format: uri
-    ThrowableProblem:
-      type: object
-      properties:
-        type:
-          type: string
-          format: uri
-        title:
-          type: string
-        status:
-          type: integer
-          format: int32
-        detail:
-          type: string
-        instance:
-          type: string
-          format: uri
-        causeAsProblem: {}
-    Violation:
-      type: object
-      properties:
-        field:
-          type: string
-        message:
-          type: string
     EsigningResponse:
       type: object
       description: Response model
@@ -658,7 +596,13 @@ components:
           - 2026-12-31T23:59:59Z
         document:
           $ref: "#/components/schemas/SigningDocument"
-          description: The document to sign
+          description: The primary document to sign
+        attachments:
+          type: array
+          description: Optional additional documents (attachments) included in the
+            signing alongside the primary document
+          items:
+            $ref: "#/components/schemas/SigningDocument"
         initiator:
           $ref: "#/components/schemas/Initiator"
           description: The initiator of the signing request

--- a/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/SigningGatewayResourceFailureTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.esigning.api;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,6 +26,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON_VALUE;
 import static se.sundsvall.esigning.TestUtil.createSignatory;
+import static se.sundsvall.esigning.TestUtil.createSigningDocument;
 import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
@@ -64,6 +66,7 @@ class SigningGatewayResourceFailureTest {
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setPartyId(null))))), "signatories[].partyId", "not a valid UUID"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setEmail(null))))), "signatories[].email", "must not be blank"),
 			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setSignatories(Set.of(createSignatory(signatory -> signatory.setEmail("not-a-valid-email"))))), "signatories[].email", "must be a well-formed email address"),
+			Arguments.of(municipalityId, createStartSigningRequest(request -> request.setAttachments(List.of(createSigningDocument(document -> document.setFileName(null))))), "attachments[0].fileName", "must not be blank"),
 			Arguments.of("not valid", createStartSigningRequest(), "createSigning.municipalityId", "not a valid municipality ID"));
 	}
 

--- a/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
+++ b/src/test/java/se/sundsvall/esigning/api/model/StartSigningRequestTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.esigning.api.model;
 
 import com.google.code.beanmatchers.BeanMatchers;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import org.hamcrest.MatcherAssert;
@@ -48,10 +49,12 @@ class StartSigningRequestTest {
 		final var message = createMessage();
 		final var initiator = createInitiator();
 		final var document = createSigningDocument();
+		final var attachments = List.of(createSigningDocument());
 
 		final var bean = StartSigningRequest.builder()
 			.withExpires(expires)
 			.withDocument(document)
+			.withAttachments(attachments)
 			.withLanguage(language)
 			.withCustomerReference(customerReference)
 			.withReminder(reminder)
@@ -69,6 +72,7 @@ class StartSigningRequestTest {
 			assertThat(b.getNotificationMessage()).isEqualTo(message);
 			assertThat(b.getInitiator()).isEqualTo(initiator);
 			assertThat(b.getDocument()).isEqualTo(document);
+			assertThat(b.getAttachments()).isEqualTo(attachments);
 		}).hasNoNullFieldsOrProperties();
 	}
 

--- a/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
+++ b/src/test/java/se/sundsvall/esigning/provider/comfact/ComfactSigningMapperTest.java
@@ -5,6 +5,7 @@ import generated.se.sundsvall.comfactfacade.SigningInstance;
 import generated.se.sundsvall.comfactfacade.Status;
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -20,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static se.sundsvall.esigning.TestUtil.createComfactEventNotification;
+import static se.sundsvall.esigning.TestUtil.createSigningDocument;
 import static se.sundsvall.esigning.TestUtil.createStartSigningRequest;
 import static se.sundsvall.esigning.provider.model.SigningStatus.FEL;
 import static se.sundsvall.esigning.provider.model.SigningStatus.INITIERAT;
@@ -61,6 +63,9 @@ class ComfactSigningMapperTest {
 		assertThat(result.getDocument().getMimeType()).isEqualTo("application/pdf");
 		assertThat(result.getDocument().getContent()).isEqualTo("test".getBytes(StandardCharsets.UTF_8));
 
+		// No attachments were provided, so no additional documents are sent.
+		assertThat(result.getAdditionalDocuments()).isEmpty();
+
 		assertThat(result.getSignatories()).hasSize(1);
 		final var mappedSignatory = result.getSignatories().getFirst();
 		assertThat(mappedSignatory.getName()).isEqualTo(signatory.getName());
@@ -68,6 +73,19 @@ class ComfactSigningMapperTest {
 		assertThat(mappedSignatory.getEmail()).isEqualTo(signatory.getEmail());
 		assertThat(mappedSignatory.getIdentifications()).hasSize(1);
 		assertThat(mappedSignatory.getIdentifications().getFirst().getAlias()).isEqualTo(ComfactSigningMapper.IDENTIFICATION_ALIAS);
+	}
+
+	@Test
+	void toComfactSigningRequest_mapsAttachmentsToAdditionalDocuments() {
+		final var request = createStartSigningRequest(r -> r.setAttachments(List.of(
+			createSigningDocument(d -> d.setFileName("attachment-1.pdf")),
+			createSigningDocument(d -> d.setFileName("attachment-2.pdf")))));
+
+		final var result = ComfactSigningMapper.toComfactSigningRequest(request);
+
+		assertThat(result.getAdditionalDocuments()).hasSize(2)
+			.extracting(Document::getFileName)
+			.containsExactly("attachment-1.pdf", "attachment-2.pdf");
 	}
 
 	@Test


### PR DESCRIPTION
StartSigningRequest gains an optional 'attachments' list (SigningDocument); ComfactSigningMapper maps it to comfact-facade's additionalDocuments so the provider signs the primary document together with its attachments. Empty/absent attachments -> no additional documents. Bean/builder + mapper + validation tests; OpenAPI regenerated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
