### PR TITLE
Bump version 2.0 → 2.1 (provider-gateway rework)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-service-e-signing</artifactId>
-	<version>2.0</version>
+	<version>2.1</version>
 	<name>api-service-e-signing</name>
 	<properties>
 		<generated-sources-path>${project.build.directory}/generated-sources</generated-sources-path>

--- a/src/main/resources/api/openapi.yml
+++ b/src/main/resources/api/openapi.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "2.0"
+  version: "2.1"
 servers:
 - url: http://localhost:57681
   description: Generated server url


### PR DESCRIPTION
Steps the module minor version for the provider-gateway rework that merged to main (POST /signings, status, webhook receiver, callback, cancel #53, attachments #54, English statuses #55) — the version had been 2.0 since long before this effort. Two-line change: pom `<version>` + the checked-in openapi `info.version`.