### PR TITLE
Sync vendored comfact-facade client spec version 3.0 → 3.1

### DIFF
--- a/src/main/resources/contract/comfactfacade.yml
+++ b/src/main/resources/contract/comfactfacade.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "3.0"
+  version: "3.1"
 servers:
   - url: http://localhost:59777
     description: Generated server url


### PR DESCRIPTION
The vendored comfact-facade contract (`contract/comfactfacade.yml`) still declared `info.version: 3.0` while api-comfact-facade is now 3.1. Bumps the string to match the provider (metadata only — not used by client generation; the withdraw/patch op used by cancel was already present). Note: greve's `stale_clients` misses this file because it lives in `contract/` rather than `integrations/`.